### PR TITLE
Handle no plist.

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -340,6 +340,8 @@ class Service
     elsif data.respond_to?(:keys) && data.keys.include?(:url)
       require 'open-uri'
       data = open(data).read
+    elsif !data
+      odie "Could not read the plist for `#{name}`!"
     end
 
     # replace "template" variables and ensure label is always, always homebrew.mxcl.<formula>


### PR DESCRIPTION
If no plist is available throw an error (instead of writing an empty plist file).

CC @gapple @DomT4 @xu-cheng 