### PR TITLE
Fix compatibility with OSX 10.8 Mountain Lion and Ruby 1.8.7

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -178,10 +178,10 @@ module ServicesCli
     # List all available services with status, user, and path to plist file
     def list
 
-      formulae = Formula.installed
-        .map { |formula|  Service.new(formula) }
-        .select { |service|  service.plist?  }
-        .map { |service|
+      formulae = Formula.installed.
+        map { |formula|  Service.new(formula) }.
+        select { |service|  service.plist?  }.
+        map { |service|
           formula = {
             :name => service.formula.name,
             :status => false,


### PR DESCRIPTION
```
cmd/brew-services.rb:183: syntax error, unexpected '.', expecting kEND
        .map { |formula|  Service.new(formula) }
         ^
cmd/brew-services.rb:184: syntax error, unexpected '.', expecting kEND
        .select { |service|  service.plist?  }
         ^
cmd/brew-services.rb:185: syntax error, unexpected '.', expecting kEND
        .map { |service|
         ^
```