### PR TITLE
Fix return if no services to control are available

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -202,7 +202,10 @@ module ServicesCli
           formula
         }
 
-      opoo("No services available to control with `#{bin}`") and return if formulae.empty?
+      if formulae.empty?
+        opoo("No services available to control with `#{bin}`")
+        return
+      end
 
       longest_name = [formulae.max_by{ |formula|  formula[:name].length }[:name].length, 4].max
       longest_user = [formulae.map{ |formula|  formula[:user].nil? ? 4 : formula[:user].length }.max, 4].max


### PR DESCRIPTION
Because `.opoo` returns `nil`, `return` was never executed because of the short circuit evaluation of `and`.

Example:
```Ruby
» a = []
» puts 'explode does not exist' and explode if a.empty?
explode does not exist
=> nil
» explode
NameError: undefined local variable or method `explode' for main:Object
from (pry):3:in `<main>'
```

This was the stack trace before:
```
$ brew services list
Warning: No services available to control with `brew services`
Error: undefined method `[]' for nil:NilClass
/usr/local/Library/Taps/homebrew/homebrew-services/cmd/brew-services.rb:207:in `list'
/usr/local/Library/Taps/homebrew/homebrew-services/cmd/brew-services.rb:162:in `run!'
/usr/local/Library/Taps/homebrew/homebrew-services/cmd/brew-services.rb:402:in `<top (required)>'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/usr/local/Library/brew.rb:60:in `require?'
/usr/local/Library/brew.rb:139:in `<main>'
```