### PR TITLE
Avoid failure exit mode if service already started

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -253,7 +253,10 @@ module ServicesCli
 
     # Start a service
     def start
-      odie "Service `#{service.name}` already started, use `#{bin} restart #{service.name}`" if service.loaded?
+      if service.loaded?
+        puts "Service `#{service.name}` already started, use `#{bin} restart #{service.name}` to restart."
+        return
+      end
 
       custom_plist = @args.first
       if custom_plist


### PR DESCRIPTION
This provides a convenient way of starting a service only if it wasn't already running and avoids using `restart`, parsing the output of `list`, or missing other important error messages when starting a service as part of an installation script.