### PR TITLE
Add hint on stop

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -193,17 +193,17 @@ module ServicesCli
       formulae = available_services.map do |service|
         formula = {
           :name => service.formula.name,
-          :status => false,
+          :started => false,
           :user => nil,
           :plist => nil
         }
 
-        if (ServicesCli.boot_path + "#{service.label}.plist").exist?
-          formula[:status] = true
+        if service.started?(as: :root)
+          formula[:started] = true
           formula[:user] = "root"
           formula[:plist] = ServicesCli.boot_path + "#{service.label}.plist"
-        elsif (ServicesCli.user_path + "#{service.label}.plist").exist?
-          formula[:status] = true
+        elsif service.started?(as: :user)
+          formula[:started] = true
           formula[:user] = ServicesCli.user
           formula[:plist] = ServicesCli.user_path + "#{service.label}.plist"
         end
@@ -221,7 +221,7 @@ module ServicesCli
 
       puts "#{Tty.white}%-#{longest_name}.#{longest_name}s %-7.7s %-#{longest_user}.#{longest_user}s %s#{Tty.reset}" % ["Name", "Status", "User", "Plist"]
       formulae.each do |formula|
-        puts "%-#{longest_name}.#{longest_name}s %s %-#{longest_user}.#{longest_user}s %s" % [formula[:name], formula[:status] ? "#{Tty.green}started#{Tty.reset}" : "stopped", formula[:user], formula[:plist]]
+        puts "%-#{longest_name}.#{longest_name}s %s %-#{longest_user}.#{longest_user}s %s" % [formula[:name], formula[:started] ? "#{Tty.green}started#{Tty.reset}" : "stopped", formula[:user], formula[:plist]]
       end
     end
 

--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -304,7 +304,11 @@ module ServicesCli
     def stop(target)
       if target.is_a?(Service) && !target.loaded?
         rm target.dest if target.dest.exist? # get rid of installed plist anyway, dude
-        odie "Service `#{target.name}` not running, wanna start it? Try `#{bin} start #{target.name}`"
+        if target.started?
+          odie "Service `#{target.name}` is started as `#{target.started_as}`. Try `#{"sudo " if ServicesCli.root?}#{bin} stop #{target.name}`"
+        else
+          odie "Service `#{target.name}` is not started."
+        end
       end
 
       Array(target).select(&:loaded?).each do |service|

--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -372,6 +372,24 @@ class Service
   # Returns `true` if service is loaded, else false.
   def loaded?; %x{#{ServicesCli.launchctl} list | grep #{label} 2>/dev/null}.chomp =~ /#{label}\z/ end
 
+  # Returns `true` if service is started (.plist is present in LaunchDaemon or LaunchAgent path), else `false`
+  # Accepts Hash option `as:` with values `:root` for LaunchDaemon path or `:user` for LaunchAgent path.
+  def started?(opts = {as: false})
+    if opts[:as] && opts[:as] == :root
+      (ServicesCli.boot_path + "#{label}.plist").exist?
+    elsif opts[:as] && opts[:as] == :user
+      (ServicesCli.user_path + "#{label}.plist").exist?
+    else
+      started?(as: :root) || started?(as: :user)
+    end
+  end
+
+  def started_as
+    return "root" if started?(as: :root)
+    return ServicesCli.user if started?(as: :user)
+    nil
+  end
+
   # Get current PID of daemon process from launchctl.
   def pid
     status = %x{#{ServicesCli.launchctl} list | grep #{label} 2>/dev/null}.chomp


### PR DESCRIPTION
Provides a hint that the service is started as `root` or `user` when trying to stop it as `user` or `root` respectively.

Say `nginx` is starting on boot as `root`, when you do `brew services list`:
```
Name         Status  User Plist
nginx        started root /Library/LaunchDaemons/homebrew.mxcl.nginx.plist
```

When you was executing `brew services stop nginx`, that was the output:
```
Error: Service `nginx` not running, wanna start it? Try `brew services start nginx`
```

Which is confusing because `nginx` is actually running, but as `root`.

After applying this patch, you will get this message:
```
Error: Service `nginx` not started as `capripot`, wanna start it? Try `brew services start nginx`
Service `nginx` is started as `root` tho, wanna stop it? Try `sudo brew services stop nginx`
```

It also uses the new method in the `list` method and fix the wording in the original message from `running` to `started`.