### PR TITLE
brew services cannot run under tmux.

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -157,6 +157,8 @@ module ServicesCli
       homebrew!
       usage if ARGV.empty? || ARGV.include?('help') || ARGV.include?('--help') || ARGV.include?('-h')
 
+      odie "brew services cannot run under tmux!" if ENV["TMUX"]
+
       # Parse arguments.
       act_on_all_services = !!ARGV.delete('--all')
       args = ARGV.reject { |arg| arg[0] == 45 }.map { |arg| arg.include?("/") ? arg : arg.downcase } # 45.chr == '-'


### PR DESCRIPTION
This is because `launchctl` gets upset about user attachments and very weird, hard-to-debug things happen. Note that we have a warning for this already in Homebrew. CC @xu-cheng 