### PR TITLE
Allow tmux if we detect reattach-to-user-namespace

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -173,7 +173,10 @@ module ServicesCli
       homebrew!
       usage if ARGV.empty? || ARGV.include?("help") || ARGV.include?("--help") || ARGV.include?("-h")
 
-      odie "brew services cannot run under tmux!" if ENV["TMUX"]
+      # pbpaste's exit status is a proxy for detecting the use of reattach-to-user-namespace
+      if ENV["TMUX"] && !quiet_system("/usr/bin/pbpaste")
+        odie "brew services cannot run under tmux!"
+      end
 
       # Parse arguments.
       act_on_all_services = !ARGV.delete("--all").nil?


### PR DESCRIPTION
The exit status of pbpaste is a proxy for whether the user has set up
reattach-to-user-namespace. It should be 0 if it is set up, 1 otherwise.