### PR TITLE
Always remove UserName key as a stopgap

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -466,17 +466,8 @@ class Service
     # Replace "template" variables and ensure label is always, always homebrew.mxcl.<formula>
     data = data.to_s.gsub(/\{\{([a-z][a-z0-9_]*)\}\}/i) { |_m| formula.send($1).to_s if formula.respond_to?($1) }.gsub(%r{(<key>Label</key>\s*<string>)[^<]*(</string>)}, '\1' + label + '\2')
 
-    # Force fix UserName
-    if !ServicesCli.root?
-      if data =~ %r{<key>UserName</key>}
-        # Replace existing UserName value with current user
-        data = data.gsub(%r{(<key>UserName</key>\s*<string>)[^<]*(</string>)}, '\1' + ServicesCli.user + '\2')
-      else
-        # Add UserName key and value to end of plist if it doesn't already exist
-        data = data.gsub(%r{(\s*</dict>\s*</plist>)}, "\n    <key>UserName</key>\n    <string>" + ServicesCli.user + "</string>\\1")
-      end
-    elsif data =~ %r{<key>UserName</key>}
-      # Always remove UserName key entirely if running as root
+    # Always remove UserName key
+    if data =~ %r{<key>UserName</key>}
       data = data.gsub(%r{(<key>UserName</key>\s*<string>)[^<]*(</string>)}, "")
     end
 


### PR DESCRIPTION
This will avoid setting the key inappropriately, but will also continue
to prevent "legitimate" use of the key (e.g., setting UserName "php" for
a daemon).

Closes #56.