### PR TITLE
Formula.factory is deprecated

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -185,7 +185,7 @@ module ServicesCli
       target = if act_on_all_services
         available_services
       elsif formula
-        Service.new(Formula.factory(formula))
+        Service.new(Formulary.factory(formula))
       end
 
       # Dispatch commands and aliases.


### PR DESCRIPTION
``` sh
$ brew services stop mongodb
Warning: Calling Formula.factory is deprecated!
Use Formulary.factory instead.
/usr/local/Library/Taps/homebrew/homebrew-services/cmd/brew-services.rb:188:in `run!'

Stopping `mongodb`... (might take a while)
==> Successfully stopped `mongodb` (label: homebrew.mxcl.mongodb)
```