### PR TITLE
Add zsh completions for brew-services

### DIFF
--- a/completions/zsh/_brew_services
+++ b/completions/zsh/_brew_services
@@ -1,0 +1,103 @@
+#compdef brew
+#autoload
+
+__brew_installed_services() {
+  local -a services
+  services=($(brew services list | awk '{print $1}' | tail -n+2))
+  _describe -t services 'installed services' services
+}
+
+__brew_services_commands() {
+  local -a commands
+  commands=(
+    'cleanup:Get rid of stale services and unused plists'
+    'list:List all services managed by brew services'
+    'restart:Gracefully restart selected service'
+    'start:Start selected service'
+    'stop:Stop selected service'
+  )
+  _describe -t commands 'commands' commands
+}
+
+__brew_services_expand_alias()
+{
+  local command_or_alias="$1"
+  local -A aliases
+  aliases=(
+    clean cleanup
+    cl cleanup
+    rm cleanup
+    ls list
+    r restart
+    relaunch restart
+    reload restart
+    launch start
+    load start
+    l start
+    s start
+    unload stop
+    terminate stop
+    u stop
+    t stop
+  )
+  command="${aliases[$command_or_alias]:-$command_or_alias}"
+  print "${command}"
+}
+
+_brew_services_cleanup() {
+  return 1
+}
+
+_brew_services_list() {
+  return 1
+}
+
+_brew_services_restart() {
+  _arguments \
+    '(2)--all[operate on all services]' \
+    '(--all)2:service:__brew_installed_services'
+}
+
+_brew_services_start() {
+  _arguments \
+    '(2)--all[operate on all services]' \
+    '(--all)2:service:__brew_installed_services' \
+    '*:plist: '
+}
+
+_brew_services_stop() {
+  _arguments \
+    '(2)--all[operate on all services]' \
+    '(--all)2:service:__brew_installed_services'
+}
+
+
+
+_brew_services() {
+  local curcontext="$curcontext" state state_descr line expl
+  local ret=1
+
+  _arguments -C \
+    '1: :->command' \
+    '*: :->service' && return 0
+
+  case $state in
+    command)
+      __brew_services_commands ;;
+    service)
+      local command_or_alias command
+      command_or_alias="${line[1]}"
+      command=$(__brew_services_expand_alias "$command_or_alias")
+
+      # change context to e.g. brew-service-list
+      curcontext="${curcontext%:*:*}:brew-services-${command}"
+      local completion_func="_brew_services_${command//-/_}"
+      _call_function ret "${completion_func}" && return ret
+
+      _message "a completion function is not defined for brew service ${command}"
+      return 1
+   ;;
+  esac
+}
+
+_brew_services "$@"


### PR DESCRIPTION
This addresses code that was lost from the changes to the completions
scripts from oh-my-zsh. It requires a change to brew to install
completion scripts, but can be manually tested before then via symlink:

```shell
ln -s /usr/local/Homebrew/Library/Taps/homebrew/homebrew-services/completions/zsh/_brew_services /usr/local/share/zsh/site-functions/_brew_services
```