### PR TITLE
Make clear start is requested not necessarily done

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -239,7 +239,7 @@ module ServicesCli
         temp.close
 
         safe_system launchctl, "load", "-w", service.dest.to_s
-        $?.to_i.nonzero? ? odie("Failed to start `#{service.name}`") : ohai("Successfully started `#{service.name}` (label: #{service.label})")
+        $?.to_i.nonzero? ? odie("Failed to start `#{service.name}`") : ohai("Successfully requested start of `#{service.name}` (label: #{service.label})")
       end
     end
 


### PR DESCRIPTION
We're not `launchctl` so we don't know if it's actually started or not (or started and died immediately) so set expectations accordingly.

CC @ilovezfs for thoughts.