### PR TITLE
Separate install and start

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ brew tap homebrew/services
 
 ## Examples ##
 
-### Install and start service mysql at login ###
+### Start service mysql ###
 
 ```
 $ brew install mysql
@@ -36,12 +36,17 @@ Restart service mysql:
 $ brew services restart mysql
 ```
 
+Install and start service mysql at login:
+
+```
+$ brew services install mysql
+```
 
 ### Install and start dnsmasq service at boot ###
 
 ```
 $ brew install dnsmasq
-$ sudo brew services start dnsmasq
+$ sudo brew services install dnsmasq
 ```
 
 ### List all services managed by `brew services` ###

--- a/completions/zsh/_brew_services
+++ b/completions/zsh/_brew_services
@@ -15,6 +15,8 @@ __brew_services_commands() {
     'restart:Gracefully restart selected service'
     'start:Start selected service'
     'stop:Stop selected service'
+    'install:Install selected service'
+    'uninstall:Uninstall selected service'
   )
   _describe -t commands 'commands' commands
 }
@@ -39,6 +41,8 @@ __brew_services_expand_alias()
     terminate stop
     u stop
     t stop
+    i install
+    remove uninstall
   )
   command="${aliases[$command_or_alias]:-$command_or_alias}"
   print "${command}"
@@ -66,6 +70,19 @@ _brew_services_start() {
 }
 
 _brew_services_stop() {
+  _arguments \
+    '(2)--all[operate on all services]' \
+    '(--all)2:service:__brew_installed_services'
+}
+
+_brew_services_install() {
+  _arguments \
+    '(2)--all[operate on all services]' \
+    '(--all)2:service:__brew_installed_services' \
+    '*:plist: '
+}
+
+_brew_services_uninstall() {
   _arguments \
     '(2)--all[operate on all services]' \
     '(--all)2:service:__brew_installed_services'

--- a/homebrew-services-backup
+++ b/homebrew-services-backup
@@ -1,1 +1,0 @@
-homebrew-services-backup

--- a/homebrew-services-backup
+++ b/homebrew-services-backup
@@ -1,0 +1,1 @@
+homebrew-services-backup


### PR DESCRIPTION
This is a proposal for separation of concerns. Sometimes, I want to start/stop a service without installing it to launch at login or boot. I tried to achieve this goal by making 2 new commands: `install` and `uninstall`.