### PR TITLE
Handle versioned formulae names.

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -290,7 +290,7 @@ class Service
 
   # Create a new `Service` instance from either a path or label.
   def self.from(path_or_label)
-    return nil unless path_or_label =~ /homebrew\.mxcl\.([^\.]+)(\.plist)?\z/
+    return unless path_or_label =~ /homebrew\.mxcl\.([\w+-.@]+)(\.plist)?\z/
     begin
       new(Formulary.factory($1))
     rescue


### PR DESCRIPTION
Previously their formula names meant that services could not be resolved through an over-strict regex.

Fixes https://github.com/Homebrew/homebrew-core/issues/7711.