### PR TITLE
Fix completion parse error

### DIFF
--- a/completions/zsh/_brew_services
+++ b/completions/zsh/_brew_services
@@ -13,7 +13,7 @@ __brew_services_commands() {
     'cleanup:Get rid of stale services and unused plists'
     'list:List all services managed by brew services'
     'restart:Gracefully restart selected service'
-    'run:Run selected service. Don'"'"'t start at login (nor boot).'
+    "run:Run selected service. Don't start at login (nor boot)."
     'start:Start selected service'
     'stop:Stop selected service'
   )

--- a/completions/zsh/_brew_services
+++ b/completions/zsh/_brew_services
@@ -13,7 +13,7 @@ __brew_services_commands() {
     'cleanup:Get rid of stale services and unused plists'
     'list:List all services managed by brew services'
     'restart:Gracefully restart selected service'
-    'run:Run selected service. Don't start at login (nor boot).'
+    'run:Run selected service. Don'"'"'t start at login (nor boot).'
     'start:Start selected service'
     'stop:Stop selected service'
   )


### PR DESCRIPTION
This PR fixes the error ``_brew_services:88: parse error near `>'`` due unescaped single quote.
An alternative way is to use UTF apostrophe `’`.