### PR TITLE
Convert to using launchctl bootstrap instead of deprecated launchctl load -w

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -1,5 +1,6 @@
-#:  * `services`
-#:    Easily start and stop formulae via launchctl
+#:  * `services` [`-v`|`--verbose`] [list | run | start | stop | restart | cleanup] [...]
+#:    Easily start and stop formulae via launchctl.
+#:    With `-v` or `--verbose`, print more detail.
 #:
 #:    Integrates Homebrew formulae with OS X's `launchctl` manager. Services can be
 #:    added to either `/Library/LaunchDaemons` or `~/Library/LaunchAgents`.

--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -237,7 +237,7 @@ module ServicesCli
       end
     end
 
-    # "load" a plist, classically
+    # "load" a plist, the newfangled way
     def launchctl_load(plist, _function, service)
       if root?
         domain_target = "system"

--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -237,6 +237,16 @@ module ServicesCli
       end
     end
 
+    # "load" a plist, classically
+    def launchctl_load(plist, function, service)
+        safe_system launchctl, "load", "-w", plist
+        if $?.to_i.nonzero?
+          odie("Failed to start `#{service.name}`")
+        else
+          ohai("Successfully started `#{service.name}` (label: #{service.label})")
+        end
+    end
+
     # Run a service.
     def run(target)
       if target.is_a?(Service) && target.loaded?
@@ -245,13 +255,7 @@ module ServicesCli
       end
 
       Array(target).each do |service|
-        safe_system launchctl, "load", "-w", service.plist
-
-        if $?.to_i.nonzero?
-          odie("Failed to start `#{service.name}`")
-        else
-          ohai("Successfully started `#{service.name}` (label: #{service.label})")
-        end
+        launchctl_load(service.plist, "ran", service)
       end
     end
 
@@ -296,13 +300,7 @@ module ServicesCli
         # Clear tempfile.
         temp.close
 
-        safe_system launchctl, "load", "-w", service.dest.to_s
-
-        if $?.to_i.nonzero?
-          odie("Failed to start `#{service.name}`")
-        else
-          ohai("Successfully started `#{service.name}` (label: #{service.label})")
-        end
+        launchctl_load(service.dest.to_s, "started", service)
       end
     end
 

--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -253,7 +253,6 @@ module ServicesCli
       end
 
       ohai("Successfully #{function} `#{service.name}` (label: #{service.label})")
-
     end
 
     # Run a service.

--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -246,20 +246,14 @@ module ServicesCli
 
       if MacOS.version >= :yosemite
         safe_system launchctl, "enable", "#{domain_target}/#{service.label}"
-        if $?.to_i.nonzero?
-          odie("Failed to enable `#{service.name}`")
-        end
-
         safe_system launchctl, "bootstrap", domain_target, plist
       else
         # This syntax was deprecated in Yosemite
         safe_system launchctl, "load", "-w", plist
       end
-      if $?.to_i.nonzero?
-        odie("Failed to start `#{service.name}`")
-      else
-        ohai("Successfully started `#{service.name}` (label: #{service.label})")
-      end
+
+      ohai("Successfully started `#{service.name}` (label: #{service.label})")
+
     end
 
     # Run a service.

--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -244,16 +244,16 @@ module ServicesCli
         domain_target = "gui/#{Process.uid}"
       end
 
-      if MacOS.version < :yosemite
-        # This syntax was deprecated in Yosemite
-        safe_system launchctl, "load", "-w", plist
-      else
+      if MacOS.version >= :yosemite
         safe_system launchctl, "enable", "#{domain_target}/#{service.label}"
         if $?.to_i.nonzero?
           odie("Failed to enable `#{service.name}`")
         end
 
         safe_system launchctl, "bootstrap", domain_target, plist
+      else
+        # This syntax was deprecated in Yosemite
+        safe_system launchctl, "load", "-w", plist
       end
       if $?.to_i.nonzero?
         odie("Failed to start `#{service.name}`")

--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -237,7 +237,6 @@ module ServicesCli
       end
     end
 
-    # "load" a plist
     def launchctl_load(plist, _function, service)
       if root?
         domain_target = "system"
@@ -249,7 +248,6 @@ module ServicesCli
         # This syntax was deprecated in Yosemite
         safe_system launchctl, "load", "-w", plist
       else
-        # New syntax has improved errr-handling.
         safe_system launchctl, "enable", "#{domain_target}/#{service.label}"
         if $?.to_i.nonzero?
           odie("Failed to enable `#{service.name}`")

--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -237,7 +237,7 @@ module ServicesCli
       end
     end
 
-    def launchctl_load(plist, _function, service)
+    def launchctl_load(plist, function, service)
       if root?
         domain_target = "system"
       else
@@ -252,7 +252,7 @@ module ServicesCli
         safe_system launchctl, "load", "-w", plist
       end
 
-      ohai("Successfully started `#{service.name}` (label: #{service.label})")
+      ohai("Successfully #{function} `#{service.name}` (label: #{service.label})")
 
     end
 


### PR DESCRIPTION
As discussed in #111, convert to using `launchctl bootstrap` (preceded by `launchctl enable`) instead of the deprecated `launchctl load -w` form.

This gives us error reporting, which fixes #111. It also means we're not using a deprecated API, which is good.  And it also paves the way for better separation of root vs. user (e.g. so the same command need not do different things in those cases), and perhaps also to fix the problems of running launchctl under tmux/screen (maybe).

While we're here, document the `-v` flag, which was useful here. (Why doesn't the usage message standout in **bold** like in the builtin commands?)

Example of error detection we didn't have before:

```
bash-3.2# brew services -v run ntp
Unsetting PERL5LIB to protect you from yourself
/bin/launchctl enable system/homebrew.mxcl.ntp
/bin/launchctl bootstrap system /usr/local/opt/ntp/homebrew.mxcl.ntp.plist
/usr/local/Cellar/ntp/4.2.8p10/homebrew.mxcl.ntp.plist: Path had bad ownership/permissions
Error: Failure while executing: /bin/launchctl bootstrap system /usr/local/opt/ntp/homebrew.mxcl.ntp.plist
```

versus

```
bash-3.2# brew services -v run ntp
Unsetting PERL5LIB to protect you from yourself
/bin/launchctl load -w /usr/local/opt/ntp/homebrew.mxcl.ntp.plist
/usr/local/Cellar/ntp/4.2.8p10/homebrew.mxcl.ntp.plist: Path had bad ownership/permissions
==> Successfully started `ntp` (label: homebrew.mxcl.ntp)
```

Also, with a deliberately malformed plist, we used to fail undetectably:

```
bash-3.2# brew services start ntp
Unsetting PERL5LIB to protect you from yourself
/Library/LaunchDaemons/homebrew.mxcl.ntp.plist: Invalid property list
==> Successfully started `ntp` (label: homebrew.mxcl.ntp)
bash-3.2# brew services stop ntp
Unsetting PERL5LIB to protect you from yourself
Error: Service `ntp` is not started.
bash-3.2# 
```

and now we do it right:

```
bash-3.2# brew -v services start ntp
Unsetting PERL5LIB to protect you from yourself
==> Generated plist for ntp:
   <?xml version="1.0" encoding="UTF-8"?>
   <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
   <plist version="1.0">
   <dict>
     <key>KeepAlive</key>
     <true/>
     <key>Label</key>
     <string>homebrew.mxcl.ntp</string>
     <key>ProgramArguments</key>
     <array>
       <string>/usr/local/opt/ntp/sbin/ntpd</string>
       <string>-c</string>
       <string>/private/etc/ntp-restrict.conf</string>
       <string>-n</string>
       <string>-g</string>
       <string>-p</string>
       <string>/var/run/ntpd.pid</string>
       <string>-f</string>
       <string>/var/db/ntp.drift</string>
       <string>-l</string>
       <string>/var/log/ntp.log</stringg>
     </array>
     <key>RunAtLoad</key>
     <true/>
   </dict>
   </plist>
   

/bin/launchctl enable system/homebrew.mxcl.ntp
/bin/launchctl bootstrap system /Library/LaunchDaemons/homebrew.mxcl.ntp.plist
/Library/LaunchDaemons/homebrew.mxcl.ntp.plist: Invalid property list
Error: Failure while executing: /bin/launchctl bootstrap system /Library/LaunchDaemons/homebrew.mxcl.ntp.plist
bash-3.2# 
```

---

Note, this was also discussed, somewhat datedly, at https://github.com/Homebrew/legacy-homebrew/issues/33259.
There was a lot of confusion in that thread, and in particular, there seemed to be the assumption that `launchctl enable` should come after `launchctl load`; that's not the case, and so doesn't work, which lead to proposals of using `launchctl kickstart`. That's unnecessary, and also sounds bad and inelegant :)