### PR TITLE
brew-services: use non-deprecated unload methods.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   # Test stop command
   - brew services stop mysql
   - sleep 5
-  - test ! `launchctl list | grep mysql`
+  - if launchctl list | grep mysql; then false; else true; fi
   # Test run command
   - brew services run mysql
   - sleep 5


### PR DESCRIPTION
Use `launchctl`'s `kill` and `disable` subcommands rather than `unload` to avoid weirdness where services aren't properly terminated.

CC @bryanaknight who ran into this.