### PR TITLE
brew-services: follow Apple guidance for launchd plist file perms

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -309,6 +309,7 @@ module ServicesCli
         rm service.dest if service.dest.exist?
         service.dest_dir.mkpath unless service.dest_dir.directory?
         cp temp.path, service.dest
+        chmod 0644, service.dest
 
         # Clear tempfile.
         temp.close


### PR DESCRIPTION
Files such as [~]/Library/LaunchDaemons/foobar.plist installed by
[sudo] brew services start foobar
ended up with overly restrictive 0600 permissions. While launchd
accepted this because it's not a security risk, other system daemons
run as non-root and need world-read on those files to work properly.