### PR TITLE
brew services stop: fix on Yosemite.

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -330,7 +330,8 @@ module ServicesCli
 
       Array(target).select(&:loaded?).each do |service|
         puts "Stopping `#{service.name}`... (might take a while)"
-        if MacOS.version >= :yosemite
+        # This command doesn't exist in Yosemite.
+        if MacOS.version >= :el_capitan
           quiet_system launchctl, "bootout", "#{domain_target}/#{service.label}"
           while $CHILD_STATUS.to_i == 9216
             sleep(5)
@@ -338,8 +339,9 @@ module ServicesCli
           end
         end
         if service.dest.exist?
-          unless MacOS.version >= :yosemite
-            # This syntax was deprecated in Yosemite
+          unless MacOS.version >= :el_capitan
+            # This syntax was deprecated in Yosemite but there's no alternative
+            # command (bootout) until El Capitan.
             safe_system launchctl, "unload", "-w", service.dest.to_s
           end
           ohai "Successfully stopped `#{service.name}` (label: #{service.label})"


### PR DESCRIPTION
The `bootout` command isn't implemented yet and `unbootstrap` does nothing.

CC @pavelrad to verify if this fixes the problem for you.

Fixes #124.