### PR TITLE
sort `brew services list` entries naturally, fixes #145

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -166,6 +166,8 @@ module ServicesCli
       return
     end
 
+    formulae.sort_by! { |f| f[:name].gsub(/\d+/) { |m| sprintf "%09d", m } }
+
     longest_name = [formulae.max_by { |formula| formula[:name].length }[:name].length, 4].max
     longest_user = [formulae.map { |formula| formula[:user].nil? ? 4 : formula[:user].length }.max, 4].max
 

--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -166,7 +166,7 @@ module ServicesCli
       return
     end
 
-    formulae.sort_by! { |f| f[:name].gsub(/\d+/) { |m| sprintf "%09d", m } }
+    formulae.sort_by! { |f| f[:name].gsub(/\d+/) { |m| "%09d" % m } }
 
     longest_name = [formulae.max_by { |formula| formula[:name].length }[:name].length, 4].max
     longest_user = [formulae.map { |formula| formula[:user].nil? ? 4 : formula[:user].length }.max, 4].max


### PR DESCRIPTION
Does a simple natural sort of the formulae before printing them, by padding any strings of digits to 9 characters.

Let me know if I missed something, or misunderstood the pull request instructions at https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request.html

Fixes #145