### PR TITLE
services: use explicit open.

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -485,7 +485,7 @@ class Service
       data = data.read
     elsif data.respond_to?(:keys) && data.keys.include?(:url)
       require "open-uri"
-      data = open(data).read
+      data = URI.parse(data).read
     elsif !data
       odie "Could not read the plist for `#{name}`!"
     end


### PR DESCRIPTION
This opens a URL directly rather than potentially allowing process execution.