### PR TITLE
Sort "brew services list" based on service name

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -118,7 +118,7 @@ module ServicesCli
 
   # List all available services with status, user, and path to the plist file.
   def list
-    formulae = available_services.map do |service|
+    formulae = available_services.sort_by(&:name).map do |service|
       formula = {
         name: service.formula.name,
         status: :stopped,


### PR DESCRIPTION
I am not sure, but I seem to remember this being sorted before. I _think_ that on HFS+, directories always returned directory listing results in sorted order, but that changed on APFS. I had the same issue in another project of mine.