### PR TITLE
Sort services in available_services instead

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -74,7 +74,7 @@ module ServicesCli
 
   # All available services
   def available_services
-    Formula.installed.map { |formula| Service.new(formula) }.select(&:plist?)
+    Formula.installed.map { |formula| Service.new(formula) }.select(&:plist?).sort_by(&:name)
   end
 
   # Run and start the command loop.
@@ -118,7 +118,7 @@ module ServicesCli
 
   # List all available services with status, user, and path to the plist file.
   def list
-    formulae = available_services.sort_by(&:name).map do |service|
+    formulae = available_services.map do |service|
       formula = {
         name: service.formula.name,
         status: :stopped,


### PR DESCRIPTION
Although I have been quite happy with my last fix (https://github.com/Homebrew/homebrew-services/pull/160), I was a little bit annoyed today that `brew services start --all` didn't start them in the same order.

Before:

```
$ brew services start --all
==> Successfully started `postgresql` (label: homebrew.mxcl.postgresql)
==> Successfully started `privoxy` (label: homebrew.mxcl.privoxy)
==> Successfully started `icinga2-redirector` (label: homebrew.mxcl.icinga2-redirector)
==> Successfully started `couchdb` (label: homebrew.mxcl.couchdb)
==> Successfully started `kibana` (label: homebrew.mxcl.kibana)
==> Successfully started `logstash` (label: homebrew.mxcl.logstash)
==> Successfully started `redis` (label: homebrew.mxcl.redis)
==> Successfully started `filebeat` (label: homebrew.mxcl.filebeat)
==> Successfully started `squid` (label: homebrew.mxcl.squid)
==> Successfully started `rabbitmq` (label: homebrew.mxcl.rabbitmq)
==> Successfully started `ssh-tunnel-proxy` (label: homebrew.mxcl.ssh-tunnel-proxy)
==> Successfully started `consul` (label: homebrew.mxcl.consul)
==> Successfully started `nginx` (label: homebrew.mxcl.nginx)
==> Successfully started `mysql` (label: homebrew.mxcl.mysql)
==> Successfully started `elasticsearch` (label: homebrew.mxcl.elasticsearch)
==> Successfully started `dnsmasq` (label: homebrew.mxcl.dnsmasq)
```

After:
```
$ brew services start --all
==> Successfully started `consul` (label: homebrew.mxcl.consul)
==> Successfully started `couchdb` (label: homebrew.mxcl.couchdb)
==> Successfully started `dnsmasq` (label: homebrew.mxcl.dnsmasq)
==> Successfully started `elasticsearch` (label: homebrew.mxcl.elasticsearch)
==> Successfully started `filebeat` (label: homebrew.mxcl.filebeat)
==> Successfully started `icinga2-redirector` (label: homebrew.mxcl.icinga2-redirector)
==> Successfully started `kibana` (label: homebrew.mxcl.kibana)
==> Successfully started `logstash` (label: homebrew.mxcl.logstash)
==> Successfully started `mysql` (label: homebrew.mxcl.mysql)
==> Successfully started `nginx` (label: homebrew.mxcl.nginx)
==> Successfully started `postgresql` (label: homebrew.mxcl.postgresql)
==> Successfully started `privoxy` (label: homebrew.mxcl.privoxy)
==> Successfully started `rabbitmq` (label: homebrew.mxcl.rabbitmq)
==> Successfully started `redis` (label: homebrew.mxcl.redis)
==> Successfully started `squid` (label: homebrew.mxcl.squid)
==> Successfully started `ssh-tunnel-proxy` (label: homebrew.mxcl.ssh-tunnel-proxy)
```