### PR TITLE
Avoid error for "start --all" when there already are services started

### DIFF
--- a/cmd/brew-services.rb
+++ b/cmd/brew-services.rb
@@ -301,7 +301,7 @@ module ServicesCli # rubocop:disable Metrics/ModuleLength
       end
     end
 
-    Array(target).each do |service|
+    Array(target).reject(&:loaded?).each do |service|
       temp = Tempfile.new(service.label)
       temp << service.generate_plist(custom_plist)
       temp.flush


### PR DESCRIPTION
Currently, `brew services start --all` will stop processing once it encounters a service that is already started. This change enables `start --all` to start any remaining services. `stop --all` already does this.

Current behavior:
```
$ brew services list
Name               Status  User   Plist
consul             stopped
couchdb            started stefan /Users/stefan/Library/LaunchAgents/homebrew.mxcl.couchdb.plist
elasticsearch@2.4  stopped

$ brew services start --all
/Users/stefan/Library/LaunchAgents/homebrew.mxcl.couchdb.plist: service already loaded
Error: Failure while executing; `/bin/launchctl bootstrap gui/501 /Users/stefan/Library/LaunchAgents/homebrew.mxcl.couchdb.plist` exited with 133.

$ brew services list
Name               Status  User   Plist
consul             started stefan /Users/stefan/Library/LaunchAgents/homebrew.mxcl.consul.plist
couchdb            started stefan /Users/stefan/Library/LaunchAgents/homebrew.mxcl.couchdb.plist
elasticsearch@2.4  stopped
```

Let me know if you can think of any issue this change may cause. Thanks!