### PR TITLE
azuze-pipelines-yml: early exit on errors.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@ jobs:
     vmImage: macOS-10.13
   steps:
     - bash: |
+        set -e
         sudo xcode-select --switch /Applications/Xcode_10.1.app/Contents/Developer
         brew update-reset
         ln -s "$PWD" "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-services"


### PR DESCRIPTION
We don't want to silently ignore failing commands.