### PR TITLE
cmd/services: adjust help output

### DIFF
--- a/cmd/services.rb
+++ b/cmd/services.rb
@@ -8,30 +8,30 @@ module Homebrew
   def services_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `services` <subcommand>
+        `services` [<subcommand>]
 
         Manage background services with macOS' `launchctl`(1) daemon manager.
 
         If `sudo` is passed, operate on `/Library/LaunchDaemons` (started at boot).
         Otherwise, operate on `~/Library/LaunchAgents` (started at login).
 
-        [`sudo`] `brew services` [`list`]
-          List all running services for the current user (or root).
+        [`sudo`] `brew services` [`list`]:
+        List all running services for the current user (or root).
 
-        [`sudo`] `brew services run` (<formula>|`--all`)
-          Run the service <formula> without registering to launch at login (or boot).
+        [`sudo`] `brew services run` (<formula>|`--all`):
+        Run the service <formula> without registering to launch at login (or boot).
 
-        [`sudo`] `brew services start` (<formula>|`--all`)
-          Start the service <formula> immediately and register it to launch at login (or boot).
+        [`sudo`] `brew services start` (<formula>|`--all`):
+        Start the service <formula> immediately and register it to launch at login (or boot).
 
-        [`sudo`] `brew services stop` (<formula>|`--all`)
-          Stop the service <formula> immediately and unregister it from launching at login (or boot).
+        [`sudo`] `brew services stop` (<formula>|`--all`):
+        Stop the service <formula> immediately and unregister it from launching at login (or boot).
 
-        [`sudo`] `brew services restart` (<formula>|`--all`)
-          Stop (if necessary) and start the service <formula> immediately and register it to launch at login (or boot).
+        [`sudo`] `brew services restart` (<formula>|`--all`):
+        Stop (if necessary) and start the service <formula> immediately and register it to launch at login (or boot).
 
-        [`sudo`] `brew services cleanup`
-          Remove all unused services.
+        [`sudo`] `brew services cleanup`:
+        Remove all unused services.
       EOS
       switch "--all", description: "Run <subcommand> on all services."
     end

--- a/lib/services_cli.rb
+++ b/lib/services_cli.rb
@@ -84,7 +84,7 @@ module Homebrew
       when "start", "launch", "load", "s", "l" then check(target) && start(target, custom_plist)
       when "stop", "unload", "terminate", "term", "t", "u" then check(target) && stop(target)
       else
-        raise UsageError, "Unknown subcommand `#{subcommand}`!"
+        raise UsageError, "unknown subcommand: #{subcommand}"
       end
     end
 
@@ -262,7 +262,7 @@ module Homebrew
           elsif File.exist?(custom_plist)
             custom_plist = Pathname.new(custom_plist)
           else
-            odie "#{custom_plist} is not a url or existing file"
+            odie "#{custom_plist} is not a URL or existing file"
           end
         elsif !target.installed?
           odie "Formula `#{target.name}` is not installed."

--- a/spec/homebrew/services_cli_spec.rb
+++ b/spec/homebrew/services_cli_spec.rb
@@ -15,7 +15,7 @@ describe Homebrew::ServicesCli do
     end
 
     it "prints help message on invalid command" do
-      expect { services_cli.run! }.to raise_error(UsageError, "Unknown subcommand `#{subcommand}`!")
+      expect { services_cli.run! }.to raise_error(UsageError, "unknown subcommand: #{subcommand}")
     end
   end
 end


### PR DESCRIPTION
Using colons before subcommand descriptions causes the man page output to indent them. Homebrew/brew#7393 applies the same effect to its `--help` output.