### PR TITLE
README: move documentation to --help.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,24 @@
 # Homebrew Services
 
-Integrates Homebrew formulae with macOS' `launchctl` manager.
+Manage background services with macOS' `launchctl` daemon manager.
 
 ## Requirements
 
 [Homebrew](https://github.com/Homebrew/brew) is used for installing the services.
 
-This does not work with Linuxbrew (so don't file Linux issues, please).
+This does not (and cannot) work with Homebrew on Linux (so don't file Linux issues, please).
 
 ## Install
 
-`brew services` is automatically installed when run.
+`brew services` is automatically installed when first run.
 
 ## Usage
 
-### Start
+See `brew services --help` or [the `brew man` output](https://docs.brew.sh/Manpage).
 
-Start the MySQL service at login with:
+## Tests
 
-```bash
-brew services start mysql
-```
-
-Start the Dnsmasq service at boot with:
-
-```bash
-sudo brew services start dnsmasq
-```
-
-Start all available services with:
-
-```bash
-brew services start --all
-```
-
-### Run
-
-Run the MySQL service but don't start it at login (nor boot) with:
-
-```bash
-brew services run mysql
-```
-
-### Stop
-
-Stop the MySQL service with:
-
-```bash
-brew services stop mysql
-```
-
-### Restart
-
-Restart the MySQL service with:
-
-```bash
-brew services restart mysql
-```
-
-### List
-
-List all services managed by `brew services` with:
-
-```bash
-brew services list
-```
-
-### Cleanup
-
-Remove all unused services with:
-
-```bash
-brew services cleanup
-```
+Tests can be run with `bundle install && bundle exec rspec`.
 
 ## Copyright
 

--- a/cmd/services.rb
+++ b/cmd/services.rb
@@ -16,7 +16,7 @@ module Homebrew
         Otherwise, operate on `~/Library/LaunchAgents` (started at login).
 
         [`sudo`] `brew services` [`list`]:
-        List all running services for the current user (or root).
+        List all managed services for the current user (or root).
 
         [`sudo`] `brew services run` (<formula>|`--all`):
         Run the service <formula> without registering to launch at login (or boot).


### PR DESCRIPTION
This is included in `brew man`, `brew services --help` and is less likely to get outdated as a result.