### PR TITLE
Remove Unmatched Quote in HomeBrew Services CLI Message

### DIFF
--- a/lib/services_cli.rb
+++ b/lib/services_cli.rb
@@ -365,7 +365,7 @@ module Homebrew
         if target.started?
           odie <<~EOS
             Service `#{target.name}` is started as `#{target.started_as}`. Try:
-              #{"sudo " unless ServicesCli.root?}#{bin} stop #{target.name}"
+              #{"sudo " unless ServicesCli.root?}#{bin} stop #{target.name}
           EOS
         else
           odie "Service `#{target.name}` is not started."


### PR DESCRIPTION
When using HomeBrew Services to stop a command originally run as `root`, a suggestion appears if `sudo` isn't specified.

Consider the following screenshot as an example:

![Screen Shot 2020-11-16 at 2 50 28 PM](https://user-images.githubusercontent.com/133372/99319416-54193480-281e-11eb-822d-85fa5784c2db.png)

As illustrated above, an accidental double quote is shown at the end of the status message `sudo brew services stop php@7.2"`.

This change proposes to fix the output of the message to omit the trailing quote.