### PR TITLE
bash-completion: separate out running commands

### DIFF
--- a/completions/bash/brew-services
+++ b/completions/bash/brew-services
@@ -2,14 +2,24 @@
 # brew services completion
 #########################################################################
 
+# Called once on shell startup
+BREW_PREFIX="$(brew --prefix)"
+
 # Complete brew services xxxxxxx
 _brew_services() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local prv="$(__brewcomp_prev)"
   case "$prv" in
-    start|stop|restart|cleanup)
+    stop|cleanup)
       # get list of agent plists, clean up with param expansion
-      local agents=( $HOME/Library/LaunchAgents/homebrew* )
+      # this only lists started services
+      local agents=( $HOME/Library/LaunchAgents/homebrew* /Library/LaunchDaemons/homebrew* )
+      agents=( "${agents[@]##*/homebrew.mxcl.}" )
+      agents=( "${agents[@]%.plist}" )
+      COMPREPLY=($(compgen -W "${agents[*]}" -- "$cur"))
+      ;;
+    start|restart|run)
+      local agents=( $(find "${BREW_PREFIX}/Cellar" -mindepth 3 -maxdepth 3 -name 'homebrew.mxcl.*.plist') )
       agents=( "${agents[@]##*/homebrew.mxcl.}" )
       agents=( "${agents[@]%.plist}" )
       COMPREPLY=($(compgen -W "${agents[*]}" -- "$cur"))

--- a/completions/bash/brew-services
+++ b/completions/bash/brew-services
@@ -3,7 +3,7 @@
 #########################################################################
 
 # Called once on shell startup
-BREW_PREFIX="$(brew --prefix)"
+HOMEBREW_PREFIX="$(brew --prefix)"
 
 # Complete brew services xxxxxxx
 _brew_services() {


### PR DESCRIPTION
The existing shell completion only found plist files that had been started, which means you had to know the name of the service to start it. This changes it so only the `stop|cleanup` uses this.
Commands that run services (`start|restart|run`) now find services using:
`find "${BREW_PREFIX}/Cellar"  -mindepth 3 -maxdepth 3 -name 'homebrew.mxcl.*.plist'`.
Where BREW_PREFIX is set on shell startup as `brew --prefix` output.

Adds active services started with `sudo` to the completions as well.

On my machine calling `brew --prefix` adds ~30ms latency to shell startup, but no impact after that. If there's a better way to find that would love to know!

I have a version that gets rid of the duplicate string expressions but it was pretty difficult to grok, going with this instead for readability.