### PR TITLE
services_cli: Fix list command wrongly showing root user as owner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,22 +42,21 @@ jobs:
 
     - name: Test start command
       run: |
-        # Test start command
-        brew install mysql
-        brew services start mysql
-        brew services list | grep mysql
+        brew install redis
+        brew services start redis
+        brew services list | grep redis
         sleep 5
-        mysql -uroot -e 'show databases'
+        redis-cli INFO | grep uptime_in_seconds
 
     - name: Test stop command
       run: |
-        brew services stop mysql
+        brew services stop redis
         sleep 5
-        if launchctl list | grep mysql; then false; else true; fi
+        if launchctl list | grep redis; then false; else true; fi
 
     - name: Test run command
       run: |
-        brew services run mysql
+        brew services run redis
         sleep 5
-        mysql -uroot -e 'show databases'
-        brew services stop mysql
+        redis-cli INFO | grep uptime_in_seconds
+        brew services stop redis

--- a/lib/services_cli.rb
+++ b/lib/services_cli.rb
@@ -38,10 +38,6 @@ module Homebrew
       Pathname.new("#{ENV["HOME"]}/Library/LaunchAgents")
     end
 
-    def user_from_standard_plist_path
-      ServicesCli.user_path.to_path.match(%r{Users/(\w+)})[1]
-    end
-
     # If root, return `boot_path`, else return `user_path`.
     def path
       root? ? boot_path : user_path
@@ -116,7 +112,7 @@ module Homebrew
           formula[:plist] = ServicesCli.boot_path + "#{service.label}.plist"
         elsif service.started?(as: :user)
           formula[:status] = :started
-          formula[:user] = ServicesCli.user_from_standard_plist_path
+          formula[:user] = ENV["HOME"].split("/").last
           formula[:plist] = ServicesCli.user_path + "#{service.label}.plist"
         elsif service.loaded?
           formula[:status] = :started

--- a/lib/services_cli.rb
+++ b/lib/services_cli.rb
@@ -23,7 +23,7 @@ module Homebrew
       Process.uid.zero?
     end
 
-    # Current user.
+    # Current user running `[sudo] brew services`.
     def user
       @user ||= `/usr/bin/whoami`.chomp
     end
@@ -36,6 +36,10 @@ module Homebrew
     # Run at login.
     def user_path
       Pathname.new("#{ENV["HOME"]}/Library/LaunchAgents")
+    end
+
+    def user_from_standard_plist_path
+      ServicesCli.user_path.to_path.match(%r{Users/(\w+)})[1]
     end
 
     # If root, return `boot_path`, else return `user_path`.
@@ -112,7 +116,7 @@ module Homebrew
           formula[:plist] = ServicesCli.boot_path + "#{service.label}.plist"
         elsif service.started?(as: :user)
           formula[:status] = :started
-          formula[:user] = ServicesCli.user
+          formula[:user] = ServicesCli.user_from_standard_plist_path
           formula[:plist] = ServicesCli.user_path + "#{service.label}.plist"
         elsif service.loaded?
           formula[:status] = :started

--- a/lib/services_cli.rb
+++ b/lib/services_cli.rb
@@ -28,6 +28,14 @@ module Homebrew
       @user ||= `/usr/bin/whoami`.chomp
     end
 
+    def user_of_process(pid)
+      if pid.nil? || pid.zero?
+        ENV["HOME"].split("/").last
+      else
+        `ps -o user -p #{pid} | grep -v USER`.chomp
+      end
+    end
+
     # Run at boot.
     def boot_path
       Pathname.new("/Library/LaunchDaemons")
@@ -112,7 +120,7 @@ module Homebrew
           formula[:plist] = ServicesCli.boot_path + "#{service.label}.plist"
         elsif service.started?(as: :user)
           formula[:status] = :started
-          formula[:user] = ENV["HOME"].split("/").last
+          formula[:user] = ServicesCli.user_of_process(service.pid)
           formula[:plist] = ServicesCli.user_path + "#{service.label}.plist"
         elsif service.loaded?
           formula[:status] = :started


### PR DESCRIPTION
- When running `brew services` with a couple of services started as a normal user, and one service started as root, this was the output:

```
➜ brew services
Name       Status  User   Plist
mosquitto  started issyl0 /Users/issyl0/Library/LaunchAgents/homebrew.mxcl.mosquitto.plist
postgresql started   issyl0 /Users/issyl0/Library/LaunchAgents/homebrew.mxcl.postgresql.plist
vault      error   root /Library/LaunchDaemons/homebrew.mxcl.vault.plist
```

- When running `sudo brew services` with the same combination of services, this was the output:

```
➜ sudo brew services
Password:
Name       Status  User Plist
mosquitto  started root /Users/issyl0/Library/LaunchAgents/homebrew.mxcl.mosquitto.plist
postgresql started root /Users/issyl0/Library/LaunchAgents/homebrew.mxcl.postgresql.plist
vault      error   root /Library/LaunchDaemons/homebrew.mxcl.vault.plist
```

- That is, the `User` column always showed `root` for all started services. That's because the `started?(as: :user)` conditional wrongly used the user invoking the `[sudo] brew services` command as the owning user for that process.

- This change fixes that by parsing the `user_path` for just the `started?(as: :user)` part of the `if` condition, and getting the username out of it.

- Fixes #287.
