### PR TITLE
services_cli: always shown "unknown" state.

### DIFF
--- a/lib/services_cli.rb
+++ b/lib/services_cli.rb
@@ -159,13 +159,7 @@ module Homebrew
         when :started then "#{Tty.green}started#{Tty.reset}"
         when :stopped then "stopped"
         when :error   then "#{Tty.red}error  #{Tty.reset}"
-        when :unknown
-          if ENV["HOMEBREW_DEVELOPER"]
-            "#{Tty.yellow}unknown#{Tty.reset}"
-          else
-            # For backwards-compatability showing unknown state as started in yellow colour
-            "#{Tty.yellow}started#{Tty.reset}"
-          end
+        when :unknown then "#{Tty.yellow}unknown#{Tty.reset}"
         end
 
         puts format("%-#{longest_name}.#{longest_name}<name>s %<status>s " \


### PR DESCRIPTION
Now that we're actually tracking the PIDs of started processes I've stopped seeing "unknown" meaning "started and running but we've lost track of it somehow".

Cautiously, let's change the behaviour here to show the `unknown` state to all users (and roll back if we get complaints about breakage).