### PR TITLE
stop using backticks and grep

### DIFF
--- a/lib/services_cli.rb
+++ b/lib/services_cli.rb
@@ -32,7 +32,7 @@ module Homebrew
       if pid.nil? || pid.zero?
         ENV["HOME"].split("/").last
       else
-        `ps -o user -p #{pid} | grep -v USER`.chomp
+        Utils.safe_popen_read("ps", "-o", "user", "-p", pid.to_s).lines.second.chomp
       end
     end
 
@@ -54,7 +54,7 @@ module Homebrew
     # Find all currently running services via launchctl list.
     def running
       # TODO: find replacement for deprecated "list"
-      `#{launchctl} list | grep homebrew.mxcl`.chomp.split("\n").map do |svc|
+      Utils.safe_popen_read("#{launchctl} list | grep homebrew").chomp.split("\n").map do |svc|
         Regexp.last_match(1) if svc =~ /(homebrew\.mxcl\..+)\z/
       end.compact
     end

--- a/spec/homebrew/service_spec.rb
+++ b/spec/homebrew/service_spec.rb
@@ -48,7 +48,7 @@ describe Homebrew::Service do
 
   describe "#loaded?" do
     it "outputs if the plist is loaded" do
-      expect(service.loaded?).to eq(nil)
+      expect(service.loaded?).to eq(false)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,14 @@ RSpec.configure do |config|
 end
 
 module Homebrew
+  module Utils
+    module_function
+
+    def safe_popen_read(_cmd)
+      ""
+    end
+  end
+
   module ServicesCli
     module_function
 
@@ -43,6 +51,12 @@ module Homebrew
 
     def quiet_system(_cmd)
       true
+    end
+  end
+
+  class Service
+    def quiet_system(*_args)
+      false
     end
   end
 end


### PR DESCRIPTION
This moves all functions to more explicit `system` calls. It also changes the status/error regex to read from the specific service page.