### PR TITLE
lib/services_cli: Pass `verbose` kwarg to `start` method

### DIFF
--- a/lib/services_cli.rb
+++ b/lib/services_cli.rb
@@ -186,7 +186,7 @@ module Homebrew
         if was_run
           run(service)
         else
-          start(service, plist_file, verbose)
+          start(service, plist_file, verbose: verbose)
         end
       end
     end


### PR DESCRIPTION
- This was breaking `brew services restart`:

```
> brew services restart mysql@5.7
Error: wrong number of arguments (given 3, expected 1..2)
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-services/lib/services_cli.rb:212:in `start'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-services/lib/services_cli.rb:189:in `block in restart'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-services/lib/services_cli.rb:181:in `each'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-services/lib/services_cli.rb:181:in `restart'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-services/cmd/services.rb:80:in `services'
/usr/local/Homebrew/Library/Homebrew/brew.rb:122:in `<main>'
```

/cc @SMillerDev as this changed in #353.

- Fixes https://github.com/Homebrew/brew/issues/11514.