### PR TITLE
Don't invoke ruby if `$HOMEBREW_PREFIX` is already defined

### DIFF
--- a/completions/bash/brew-services
+++ b/completions/bash/brew-services
@@ -3,7 +3,7 @@
 #########################################################################
 
 # Called once on shell startup
-HOMEBREW_PREFIX="$(brew --prefix)"
+: "${HOMEBREW_PREFIX:=$(brew --prefix)}"
 
 # Complete brew services xxxxxxx
 _brew_services() {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Don't run `brew --prefix` if `$HOMEBREW_PREFIX` variable is already defined, improving shell startup time.