### PR TITLE
lib/services_cli: Fix not-running service status always being "unknown"

### DIFF
--- a/lib/services_cli.rb
+++ b/lib/services_cli.rb
@@ -112,7 +112,7 @@ module Homebrew
       true
     end
 
-    def service_get_status(service)
+    def service_get_operational_status(service)
       if service.pid?
         :started
       elsif service.error?
@@ -120,8 +120,6 @@ module Homebrew
         :error
       elsif service.unknown_status?
         :unknown
-      else
-        :stopped
       end
     end
 
@@ -130,6 +128,7 @@ module Homebrew
       formulae = available_services.map do |service|
         formula = {
           name:  service.formula.name,
+          status: :stopped,
           user:  nil,
           plist: nil,
         }
@@ -145,7 +144,9 @@ module Homebrew
           formula[:plist] = service.service_file
         end
 
-        formula[:status] = service_get_status(service)
+        # If we have a plist or a user defined, check if the service is running or errored.
+        formula[:status] = service_get_operational_status(service) if formula[:user] && formula[:plist]
+
         formula
       end
 

--- a/lib/services_cli.rb
+++ b/lib/services_cli.rb
@@ -127,10 +127,10 @@ module Homebrew
     def list
       formulae = available_services.map do |service|
         formula = {
-          name:  service.formula.name,
+          name:   service.formula.name,
           status: :stopped,
-          user:  nil,
-          plist: nil,
+          user:   nil,
+          plist:  nil,
         }
 
         if service.service_file_present?(for: :root) && service.pid?

--- a/spec/homebrew/services_cli_spec.rb
+++ b/spec/homebrew/services_cli_spec.rb
@@ -157,23 +157,14 @@ describe Homebrew::ServicesCli do
     end
   end
 
-  describe "#service_get_status" do
-    it "checks the fallback" do
-      service = OpenStruct.new(
-        pid?:            false,
-        error?:          false,
-        unknown_status?: false,
-      )
-      expect(services_cli.service_get_status(service)).to eq(:stopped)
-    end
-
+  describe "#service_get_operational_status" do
     it "checks unknown_status" do
       service = OpenStruct.new(
         pid?:            false,
         error?:          false,
         unknown_status?: true,
       )
-      expect(services_cli.service_get_status(service)).to eq(:unknown)
+      expect(services_cli.service_get_operational_status(service)).to eq(:unknown)
     end
 
     it "checks error" do
@@ -182,7 +173,7 @@ describe Homebrew::ServicesCli do
         error?:          true,
         unknown_status?: false,
       )
-      expect(services_cli.service_get_status(service)).to eq(:error)
+      expect(services_cli.service_get_operational_status(service)).to eq(:error)
     end
 
     it "checks error output" do
@@ -193,7 +184,7 @@ describe Homebrew::ServicesCli do
         exit_code:       40,
       )
       expect do
-        services_cli.service_get_status(service)
+        services_cli.service_get_operational_status(service)
       end.to output("40\n").to_stdout
     end
 
@@ -203,7 +194,7 @@ describe Homebrew::ServicesCli do
         error?:          false,
         unknown_status?: false,
       )
-      expect(services_cli.service_get_status(service)).to eq(:started)
+      expect(services_cli.service_get_operational_status(service)).to eq(:started)
     end
   end
 end


### PR DESCRIPTION
- This was buggy such that a not running service without a PID would default to showing as "unknown". This is because the `service_get_status` method would never fall through to the `else` condition of `:stopped`.  It was always being caught by `service.unknown_status?` because there was no PID and `formula[:status]` was blank as it wasn't being set first of all.
- This fixes it such that `formula[:status]` starts off as `:stopped`, then we set it to `:started` if a PID exists, as we did before 44f7fc0aeb8f2e594caa5e1b6e3317d49ebbe8bd.
- Given we're only checking if the service is started or otherwise errored, I renamed `service_get_status` to `service_get_operational_status` as it was clearer to me.
- I removed the fallback test as there is no fallback - ":stopped" is a service's default value again now.

- Fixes #368.
----

Before this change:

```shell
❯ brew services list
Name       Status  User   Plist
mysql      unknown
nginx      started issyl0 /Users/issyl0/Library/LaunchAgents/homebrew.mxcl.nginx.plist
postgresql unknown
redis      started issyl0 /Users/issyl0/Library/LaunchAgents/homebrew.mxcl.redis.plist
unbound    unknown
```

After this change:

```shell
❯ brew services list
Name       Status  User   Plist
mysql      stopped
nginx      started issyl0 /Users/issyl0/Library/LaunchAgents/homebrew.mxcl.nginx.plist
postgresql stopped
redis      started issyl0 /Users/issyl0/Library/LaunchAgents/homebrew.mxcl.redis.plist
unbound    stopped
```
