### PR TITLE
Display a more helpful error message when attempting to start a service for a formula that hasn't been installed.

### DIFF
--- a/lib/service/services_cli.rb
+++ b/lib/service/services_cli.rb
@@ -415,6 +415,10 @@ module Service
     end
 
     def install_service_file(service, file)
+      unless service.installed?
+        odie "Formula `#{service.name}` is not installed"
+      end
+
       unless service.service_file.exist?
         odie "Formula `#{service.name}` has not implemented #plist, #service or installed a locatable service file"
       end


### PR DESCRIPTION
### Example
(If you haven't installed the postgres formula)

#### BEFORE
```
$ brew services start postgres
Error: Formula `postgresql` has not implemented #plist, #service or installed a locatable service file
```
:rotating_light: This misleading error message implies that there's something wrong with the formula!!

#### AFTER
```
$ brew services start postgres
Error: Formula `postgresql` is not installed
```