### PR TITLE
list: move logic to command

### DIFF
--- a/lib/service/commands/list.rb
+++ b/lib/service/commands/list.rb
@@ -1,12 +1,50 @@
 # frozen_string_literal: true
 
+require "service/formulae"
+
 module Service
   module Commands
     module List
       module_function
 
       def run
-        ServicesCli.list
+        formulae = Formulae.services_list
+        if formulae.empty?
+          opoo("No services available to control with `#{Service::ServicesCli.bin}`")
+          return
+        end
+        print_table(formulae)
+      end
+
+      # Print the table in the CLI
+      # @private
+      def print_table(formulae)
+        longest_name = [formulae.max_by { |formula| formula[:name].length }[:name].length, 4].max
+        longest_user = [formulae.map { |formula| formula[:user].nil? ? 4 : formula[:user].length }.max, 4].max
+
+        headers = "#{Tty.bold}%-#{longest_name}.#{longest_name}<name>s %-7.7<status>s " \
+                  "%-#{longest_user}.#{longest_user}<user>s %<file>s#{Tty.reset}"
+        puts format(headers, name: "Name", status: "Status", user: "User", file: "File")
+
+        formulae.each do |formula|
+          status = get_status_string(formula[:status])
+          file  = formula[:file]&.to_s&.sub! ENV["HOME"], "~"
+
+          row = "%-#{longest_name}.#{longest_name}<name>s %<status>s " \
+                "%-#{longest_user}.#{longest_user}<user>s %<file>s"
+          puts format(row, name: formula[:name], status: status, user: formula[:user], file: file)
+        end
+      end
+
+      # Get formula status output
+      # @private
+      def get_status_string(status)
+        case status
+        when :started then "#{Tty.green}started#{Tty.reset}"
+        when :stopped then "stopped"
+        when :error   then "#{Tty.red}error  #{Tty.reset}"
+        when :unknown then "#{Tty.yellow}unknown#{Tty.reset}"
+        end
       end
     end
   end

--- a/lib/service/formulae.rb
+++ b/lib/service/formulae.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Service
+  module Formulae
+    module_function
+
+    # All available services
+    # @private
+    def available_services
+      require "formula"
+
+      Formula.installed.map { |formula| FormulaWrapper.new(formula) }.select(&:plist?).sort_by(&:name)
+    end
+
+    # List all available services with status, user, and path to the file.
+    def services_list
+      available_services.map do |service|
+        formula = {
+          name:   service.formula.name,
+          status: :stopped,
+          user:   nil,
+          file:   nil,
+        }
+
+        if service.service_file_present?(for: :root) && service.pid?
+          formula[:user] = "root"
+          formula[:file] = ServicesCli.boot_path + service.service_file.basename
+        elsif service.service_file_present?(for: :user) && service.pid?
+          formula[:user] = ServicesCli.user_of_process(service.pid)
+          formula[:file] = ServicesCli.user_path + service.service_file.basename
+        elsif service.loaded?
+          formula[:user] = ServicesCli.user
+          formula[:file] = service.service_file
+        end
+
+        # If we have a file or a user defined, check if the service is running or errored.
+        if formula[:user] && formula[:file]
+          formula[:status] =
+            Service::ServicesCli.service_get_operational_status(service)
+        end
+
+        formula
+      end
+    end
+  end
+end


### PR DESCRIPTION
Moves the command output generation into the command and cleans up the output better (file instead of plist and `~/` instead of `/Users/x/`