### PR TITLE
fix: --all flag causing a unknown method `available_services` error

### DIFF
--- a/cmd/services.rb
+++ b/cmd/services.rb
@@ -71,7 +71,7 @@ module Homebrew
     end
 
     target = if args.all?
-      Service::ServicesCli.available_services
+      Service::Formulae.available_services
     elsif formula
       Service::FormulaWrapper.new(Formulary.factory(formula))
     end


### PR DESCRIPTION
Commit 7c4a420 moved the available_services class method from
Service::ServicesCli to Service::Formulae, but cmd/service.rb still
referred to the old class, causing a unknown method error.