### PR TITLE
chore: always use service arrays

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,7 @@ jobs:
       run: |
         brew services stop redis
         sleep 5
+        brew services run redis
         brew services restart redis
         brew services list | grep redis
         sleep 5

--- a/lib/service/commands/cleanup.rb
+++ b/lib/service/commands/cleanup.rb
@@ -5,6 +5,8 @@ module Service
     module Cleanup
       module_function
 
+      TRIGGERS = %w[cleanup clean cl rm].freeze
+
       def run
         cleaned = []
 

--- a/lib/service/commands/list.rb
+++ b/lib/service/commands/list.rb
@@ -7,6 +7,8 @@ module Service
     module List
       module_function
 
+      TRIGGERS = [nil, "list", "ls"].freeze
+
       def run
         formulae = Formulae.services_list
         if formulae.empty?

--- a/lib/service/commands/run.rb
+++ b/lib/service/commands/run.rb
@@ -5,9 +5,11 @@ module Service
     module Run
       module_function
 
-      def run(target, verbose:)
-        ServicesCli.check(target) &&
-          ServicesCli.run(target, verbose: verbose)
+      TRIGGERS = ["run"].freeze
+
+      def run(targets, verbose:)
+        ServicesCli.check(targets) &&
+          ServicesCli.run(targets, verbose: verbose)
       end
     end
   end

--- a/lib/service/commands/start.rb
+++ b/lib/service/commands/start.rb
@@ -5,9 +5,11 @@ module Service
     module Start
       module_function
 
-      def run(target, custom_plist, verbose:)
-        ServicesCli.check(target) &&
-          ServicesCli.start(target, custom_plist, verbose: verbose)
+      TRIGGERS = %w[start launch load s l].freeze
+
+      def run(targets, custom_plist, verbose:)
+        ServicesCli.check(targets) &&
+          ServicesCli.start(targets, custom_plist, verbose: verbose)
       end
     end
   end

--- a/lib/service/commands/stop.rb
+++ b/lib/service/commands/stop.rb
@@ -5,9 +5,11 @@ module Service
     module Stop
       module_function
 
-      def run(target, verbose:)
-        ServicesCli.check(target) &&
-          ServicesCli.stop(target, verbose: verbose)
+      TRIGGERS = %w[stop unload terminate term t u].freeze
+
+      def run(targets, verbose:)
+        ServicesCli.check(targets) &&
+          ServicesCli.stop(targets, verbose: verbose)
       end
     end
   end

--- a/lib/service/formulae.rb
+++ b/lib/service/formulae.rb
@@ -35,8 +35,7 @@ module Service
 
         # If we have a file or a user defined, check if the service is running or errored.
         if formula[:user] && formula[:file]
-          formula[:status] =
-            Service::ServicesCli.service_get_operational_status(service)
+          formula[:status] = Service::ServicesCli.service_get_operational_status(service)
         end
 
         formula

--- a/spec/homebrew/formula_wrapper_spec.rb
+++ b/spec/homebrew/formula_wrapper_spec.rb
@@ -205,7 +205,7 @@ describe Service::FormulaWrapper do
       allow(Service::System).to receive(:systemctl?).and_return(false)
       expect do
         service.generate_plist(nil)
-      end.to output("Could not read the plist for `mysql`!\n").to_stdout
+      end.to raise_error TestExit, "Could not read the plist for `mysql`!"
     end
   end
 end

--- a/spec/homebrew/services_cli_spec.rb
+++ b/spec/homebrew/services_cli_spec.rb
@@ -36,14 +36,150 @@ describe Service::ServicesCli do
   describe "#check" do
     it "checks the input does not exist" do
       expect do
-        services_cli.check(nil)
-      end.to output("Formula(e) missing, please provide a formula name or use --all\n").to_stdout
+        services_cli.check([])
+      end.to raise_error UsageError, "Formula(e) missing, please provide a formula name or use --all"
     end
 
     it "checks the input exists" do
       expect do
         services_cli.check("hello")
       end.not_to output("Formula(e) missing, please provide a formula name or use --all\n").to_stdout
+    end
+  end
+
+  describe "#run" do
+    it "checks empty targets cause no error" do
+      expect(Service::System).not_to receive(:root?)
+      services_cli.run([])
+    end
+  end
+
+  describe "#start" do
+    it "checks missing file causes error" do
+      expect(Service::System).not_to receive(:root?)
+      expect do
+        services_cli.start([], "/hfdkjshksdjhfkjsdhf/fdsjghsdkjhb")
+      end.to raise_error UsageError, "Provided service file does not exist"
+    end
+
+    it "checks empty targets cause no error" do
+      expect(Service::System).not_to receive(:root?)
+      services_cli.start([])
+    end
+  end
+
+  describe "#stop" do
+    it "checks empty targets cause no error" do
+      expect(Service::System).not_to receive(:root?)
+      services_cli.stop([])
+    end
+  end
+
+  describe "#install_service_file" do
+    it "checks service is installed" do
+      expect do
+        services_cli.install_service_file(OpenStruct.new(name: "name", installed?: false), nil)
+      end.to raise_error TestExit, "Formula `name` is not installed"
+    end
+
+    it "checks service file exists" do
+      service = OpenStruct.new(name: "name", installed?: true, service_file: OpenStruct.new(exist?: false))
+      expect do
+        services_cli.install_service_file(service, nil)
+      end.to raise_error TestExit,
+                         "Formula `name` has not implemented #plist, #service or installed a locatable service file"
+    end
+  end
+
+  describe "#systemd_load" do
+    it "checks non-enabling run" do
+      expect(Service::System).to receive(:systemctl_scope).once.and_return("--user")
+      expect(Service::System).to receive(:systemctl).once.and_return("/bin/launchctl")
+      services_cli.systemd_load(OpenStruct.new(service_name: "name"), enable: false)
+    end
+
+    it "checks enabling run" do
+      expect(Service::System).to receive(:systemctl_scope).exactly(2).and_return("--user")
+      expect(Service::System).to receive(:systemctl).exactly(2).and_return("/bin/launchctl")
+      services_cli.systemd_load(OpenStruct.new(service_name: "name"), enable: true)
+    end
+  end
+
+  describe "#launchctl_load" do
+    it "checks non-enabling run" do
+      expect(Service::System).to receive(:domain_target).once.and_return("target")
+      expect(Service::System).to receive(:launchctl).once.and_return("/bin/launchctl")
+      services_cli.launchctl_load({}, file: "a", enable: false)
+    end
+
+    it "checks enabling run" do
+      expect(Service::System).to receive(:domain_target).exactly(2).and_return("target")
+      expect(Service::System).to receive(:launchctl).exactly(2).and_return("/bin/launchctl")
+      services_cli.launchctl_load(OpenStruct.new(service_name: "name"), file: "a", enable: true)
+    end
+  end
+
+  describe "#service_load" do
+    it "checks non-root for login" do
+      expect(Service::System).to receive(:launchctl?).once.and_return(false)
+      expect(Service::System).to receive(:systemctl?).once.and_return(false)
+      expect(Service::System).to receive(:root?).once.and_return(true)
+      out = "name must be run as non-root to start at user login!\nSuccessfully ran `name` (label: service.name)\n"
+      expect do
+        services_cli.service_load(
+          OpenStruct.new(name: "name", service_name: "service.name", service_startup?: false), enable: false
+        )
+      end.to output(out).to_stdout
+    end
+
+    it "checks root for startup" do
+      expect(Service::System).to receive(:launchctl?).once.and_return(false)
+      expect(Service::System).to receive(:systemctl?).once.and_return(false)
+      expect(Service::System).to receive(:root?).exactly(2).and_return(false)
+      out = "name must be run as root to start at system startup!\nSuccessfully ran `name` (label: service.name)\n"
+      expect do
+        services_cli.service_load(OpenStruct.new(name: "name", service_name: "service.name", service_startup?: true),
+                                  enable: false)
+      end.to output(out).to_stdout
+    end
+
+    it "triggers launchctl" do
+      expect(Service::System).to receive(:domain_target).once.and_return("target")
+      expect(Service::System).to receive(:launchctl?).once.and_return(true)
+      expect(Service::System).to receive(:launchctl).once
+      expect(Service::System).not_to receive(:systemctl?)
+      expect(Service::System).to receive(:root?).exactly(2).and_return(false)
+      expect do
+        services_cli.service_load(
+          OpenStruct.new(name: "name", service_name: "service.name", service_startup?: false), enable: false
+        )
+      end.to output("Successfully ran `name` (label: service.name)\n").to_stdout
+    end
+
+    it "triggers systemctl" do
+      expect(Service::System).to receive(:launchctl?).once.and_return(false)
+      expect(Service::System).to receive(:systemctl?).once.and_return(true)
+      expect(Service::System).to receive(:systemctl).once
+      expect(Service::System).to receive(:systemctl_scope).once
+      expect(Service::System).to receive(:root?).exactly(2).and_return(false)
+      expect do
+        services_cli.service_load(
+          OpenStruct.new(name: "name", service_name: "service.name", service_startup?: false), enable: false
+        )
+      end.to output("Successfully ran `name` (label: service.name)\n").to_stdout
+    end
+
+    it "represents correct action" do
+      expect(Service::System).to receive(:launchctl?).once.and_return(false)
+      expect(Service::System).to receive(:systemctl?).once.and_return(true)
+      expect(Service::System).to receive(:systemctl).exactly(2)
+      expect(Service::System).to receive(:systemctl_scope).exactly(2)
+      expect(Service::System).to receive(:root?).exactly(2).and_return(false)
+      expect do
+        services_cli.service_load(
+          OpenStruct.new(name: "name", service_name: "service.name", service_startup?: false), enable: true
+        )
+      end.to output("Successfully started `name` (label: service.name)\n").to_stdout
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,6 +66,14 @@ module Service
     end
 
     def odie(string)
+      raise TestExit, string
+    end
+
+    def opoo(string)
+      puts string
+    end
+
+    def ohai(string)
       puts string
     end
   end
@@ -76,7 +84,7 @@ module Service
     end
 
     def odie(string)
-      puts string
+      raise TestExit, string
     end
   end
 end

--- a/spec/stub/exceptions.rb
+++ b/spec/stub/exceptions.rb
@@ -2,3 +2,6 @@
 
 class UsageError < RuntimeError
 end
+
+class TestExit < RuntimeError
+end


### PR DESCRIPTION
Always pass targets as an array, and always do all validations.

This also moves the restart logic and adds a bunch of tests, getting total coverage to 70% of the LOC