### PR TITLE
Fixed bug with not working systemctl on linux

### DIFF
--- a/lib/service/formula_wrapper.rb
+++ b/lib/service/formula_wrapper.rb
@@ -83,6 +83,7 @@ module Service
         # TODO: find replacement for deprecated "list"
         quiet_system System.launchctl, "list", service_name
       elsif System.systemctl?
+        ENV['XDG_RUNTIME_DIR'] = ENV['XDG_RUNTIME_DIR'] || "/run/user/" + Process.uid.to_s  
         quiet_system System.systemctl, System.systemctl_scope, "list-unit-files", service_file.basename
       end
     end
@@ -159,6 +160,7 @@ module Service
       @status ||= if System.launchctl?
         Utils.popen_read(System.launchctl, "list", service_name).chomp
       elsif System.systemctl?
+        ENV['XDG_RUNTIME_DIR'] = ENV['XDG_RUNTIME_DIR'] || "/run/user/" + Process.uid.to_s     
         Utils.popen_read(System.systemctl.to_s, System.systemctl_scope.to_s, "status",
                          service_name.to_s).chomp
       end


### PR DESCRIPTION
If you use homebrew-services on linux or wsl(with systemctl).
Then on some distros there is no "XDG_RUNTIME_DIR".
That means there is no current user set. So the --user in the systemctl command won't have a referenced user.

With this fix, the brew services command fixed.