### PR TITLE
Prepend `System` to domain targets

### DIFF
--- a/lib/service/services_cli.rb
+++ b/lib/service/services_cli.rb
@@ -165,12 +165,12 @@ module Service
 
     # Kill a service that has no plist file.
     def kill(service)
-      quiet_system System.launchctl, "kill", "SIGTERM", "#{domain_target}/#{service.service_name}"
+      quiet_system System.launchctl, "kill", "SIGTERM", "#{System.domain_target}/#{service.service_name}"
       while service.loaded?
         sleep(5)
         break if service.loaded?
 
-        quiet_system System.launchctl, "kill", "SIGKILL", "#{domain_target}/#{service.service_name}"
+        quiet_system System.launchctl, "kill", "SIGKILL", "#{System.domain_target}/#{service.service_name}"
       end
       ohai "Successfully stopped `#{service.name}` via #{service.service_name}"
     end


### PR DESCRIPTION
While running `brew services cleanup` today, I got this stack trace:

```
brew services cleanup
launch          stale => killing service...
Error: undefined local variable or method `domain_target' for Service::ServicesCli:Module
/opt/homebrew/Library/Taps/homebrew/homebrew-services/lib/service/services_cli.rb:168:in `kill'
/opt/homebrew/Library/Taps/homebrew/homebrew-services/lib/service/services_cli.rb:55:in `block in kill_orphaned_services'
/opt/homebrew/Library/Taps/homebrew/homebrew-services/lib/service/services_cli.rb:51:in `each'
/opt/homebrew/Library/Taps/homebrew/homebrew-services/lib/service/services_cli.rb:51:in `kill_orphaned_services'
/opt/homebrew/Library/Taps/homebrew/homebrew-services/lib/service/commands/cleanup.rb:13:in `run'
/opt/homebrew/Library/Taps/homebrew/homebrew-services/cmd/services.rb:88:in `services'
/opt/homebrew/Library/Homebrew/brew.rb:110:in `<main>'
```

Looking around in the file, I noticed all the other `domain_target` calls were actually `System.domain_target`.