### PR TITLE
formula_wrapper: allow missing exit code

### DIFF
--- a/lib/service/formula_wrapper.rb
+++ b/lib/service/formula_wrapper.rb
@@ -202,7 +202,7 @@ module Service
         :started
       elsif !loaded?
         :none
-      elsif exit_code.zero?
+      elsif exit_code.present? && exit_code.zero?
         if timed?
           :scheduled
         else


### PR DESCRIPTION
Check if exit code is present before checking the value.