### PR TITLE
Fix `brew services list` columns

### DIFF
--- a/spec/homebrew/commands/list_spec.rb
+++ b/spec/homebrew/commands/list_spec.rb
@@ -18,7 +18,7 @@ describe Service::Commands::List do
     end
 
     it "succeeds with list" do
-      out = "<BOLD>Name    Status  User File<RESET>\nservice <GREEN>started<RESET> user /dev/null\n"
+      out = "<BOLD>Name    Status       User File<RESET>\nservice <GREEN>started<RESET> user /dev/null\n"
       formula = OpenStruct.new(name: "service", user: "user", status: :started, file: +"/dev/null", loaded: true)
       expect(Service::Formulae).to receive(:services_list).and_return([formula])
       expect do
@@ -32,14 +32,14 @@ describe Service::Commands::List do
       formula = { name: "a", user: "u", file: Pathname.new("/tmp/file.file"), status: :stopped }
       expect do
         described_class.print_table([formula])
-      end.to output("<BOLD>Name Status  User File<RESET>\na    stopped u    \n").to_stdout
+      end.to output("<BOLD>Name Status         User File<RESET>\na    <DEFAULT>stopped<RESET> u    \n").to_stdout
     end
 
     it "prints without user or file data" do
       formula = { name: "a", user: nil, file: nil, status: :started, loaded: true }
       expect do
         described_class.print_table([formula])
-      end.to output("<BOLD>Name Status  User File<RESET>\na    <GREEN>started<RESET>      \n").to_stdout
+      end.to output("<BOLD>Name Status       User File<RESET>\na    <GREEN>started<RESET>      \n").to_stdout
     end
 
     it "prints shortened home directory" do
@@ -47,7 +47,16 @@ describe Service::Commands::List do
       formula = { name: "a", user: "u", file: Pathname.new("/tmp/file.file"), status: :started, loaded: true }
       expect do
         described_class.print_table([formula])
-      end.to output("<BOLD>Name Status  User File<RESET>\na    <GREEN>started<RESET> u    ~/file.file\n").to_stdout
+      end.to output("<BOLD>Name Status       User File<RESET>\na    <GREEN>started<RESET> u    ~/file.file\n").to_stdout
+    end
+
+    it "prints an error code" do
+      file = Pathname.new("/tmp/file.file")
+      formula = { name: "a", user: "u", file: file, status: :error, exit_code: 256, loaded: true }
+      expected_output = "<BOLD>Name Status        User File<RESET>\na    <RED>error  <RESET>256 u    /tmp/file.file\n"
+      expect do
+        described_class.print_table([formula])
+      end.to output(expected_output).to_stdout
     end
   end
 
@@ -57,7 +66,7 @@ describe Service::Commands::List do
     end
 
     it "returns stopped" do
-      expect(described_class.get_status_string(:stopped)).to eq("stopped")
+      expect(described_class.get_status_string(:stopped)).to eq("<DEFAULT>stopped<RESET>")
     end
 
     it "returns error" do

--- a/spec/homebrew/commands/list_spec.rb
+++ b/spec/homebrew/commands/list_spec.rb
@@ -45,9 +45,10 @@ describe Service::Commands::List do
     it "prints shortened home directory" do
       ENV["HOME"] = "/tmp"
       formula = { name: "a", user: "u", file: Pathname.new("/tmp/file.file"), status: :started, loaded: true }
+      expected_output = "<BOLD>Name Status       User File<RESET>\na    <GREEN>started<RESET> u    ~/file.file\n"
       expect do
         described_class.print_table([formula])
-      end.to output("<BOLD>Name Status       User File<RESET>\na    <GREEN>started<RESET> u    ~/file.file\n").to_stdout
+      end.to output(expected_output).to_stdout
     end
 
     it "prints an error code" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,6 +61,10 @@ module Tty
     "<RED>"
   end
 
+  def default
+    "<DEFAULT>"
+  end
+
   def bold
     "<BOLD>"
   end


### PR DESCRIPTION
I noticed that in certain situation, `brew services list` doesn't property column-ify its output:

```console
$ brew services list
Name      Status  User         File
mosquitto started rylanpolster ~/Library/LaunchAgents/homebrew.mxcl.mosquitto.plist
stubby    error  256 rylanpolster ~/Library/LaunchAgents/homebrew.mxcl.stubby.plist
unbound   none
znc       scheduled rylanpolster ~/Library/LaunchAgents/homebrew.mxcl.znc.plist
```

This is because it assumes that the longest possible status string is 7 characters. This is no longer true, though, since `scheduled` and `error 256` are both longer.

I rewrote the method that outputs these columns to check for the longest status column and pad every other item to that width. This is complicated a little bit by the color codes from `Tty.color` and `Tty.reset`. These characters are counted toward the cutoff number in the format string, but aren't rendered. I think the way I did it makes sense, but I'm definitely open to suggestions if it's not clear enough.

The new output:

```console
$ brew services list
Name      Status     User         File
mosquitto started    rylanpolster ~/Library/LaunchAgents/homebrew.mxcl.mosquitto.plist
stubby    error  256 rylanpolster ~/Library/LaunchAgents/homebrew.mxcl.stubby.plist
unbound   none
znc       scheduled  rylanpolster ~/Library/LaunchAgents/homebrew.mxcl.znc.plist
```
