### PR TITLE
lib/service/commands/list: only output "no services" warning with TTY.

### DIFF
--- a/lib/service/commands/list.rb
+++ b/lib/service/commands/list.rb
@@ -11,8 +11,8 @@ module Service
 
       def run
         formulae = Formulae.services_list
-        if formulae.empty?
-          opoo("No services available to control with `#{Service::ServicesCli.bin}`")
+        if formulae.blank?
+          opoo "No services available to control with `#{Service::ServicesCli.bin}`" if $stderr.tty?
           return
         end
         print_table(formulae)

--- a/spec/homebrew/commands/list_spec.rb
+++ b/spec/homebrew/commands/list_spec.rb
@@ -11,6 +11,7 @@ describe Service::Commands::List do
 
   describe "#run" do
     it "fails with empty list" do
+      allow_any_instance_of(IO).to receive(:tty?).and_return(true)
       expect(Service::Formulae).to receive(:services_list).and_return([])
       expect do
         described_class.run


### PR DESCRIPTION
This avoids it being output when using `brew bundle` or other tools that parse `brew services` output.

Fixes #438