### PR TITLE
Small bug fix for ServicesCli.start() function

### DIFF
--- a/lib/service/services_cli.rb
+++ b/lib/service/services_cli.rb
@@ -86,7 +86,7 @@ module Service
         raise UsageError, "Provided service file does not exist" unless file.exist?
       end
 
-      targets.reject(&:pid?).each do |service|
+      targets.each do |service|
         if service.pid?
           puts "Service `#{service.name}` already started, use `#{bin} restart #{service.name}` to restart."
           next

--- a/spec/homebrew/services_cli_spec.rb
+++ b/spec/homebrew/services_cli_spec.rb
@@ -54,8 +54,9 @@ describe Service::ServicesCli do
     end
 
     it "checks if target service is already running and suggests restart instead" do
-      expected_output = "Service `example_service` already running, use `brew services restart example_service` to restart.\n"
-      service = instance_double("service", :name => "example_service", :pid? => true)
+      expected_output = "Service `example_service` already running," +
+        " use `brew services restart example_service` to restart.\n"
+      service = instance_double("service", name: "example_service", pid?: true)
       expect do
         services_cli.run([service])
       end.to output(expected_output).to_stdout
@@ -76,8 +77,9 @@ describe Service::ServicesCli do
     end
 
     it "checks if target service has already been started and suggests restart instead" do
-      expected_output = "Service `example_service` already started, use `brew services restart example_service` to restart.\n"
-      service = instance_double("service", :name => "example_service", :pid? => true)
+      expected_output = "Service `example_service` already started," +
+        " use `brew services restart example_service` to restart.\n"
+      service = instance_double("service", name: "example_service", pid?: true)
       expect do
         services_cli.start([service])
       end.to output(expected_output).to_stdout

--- a/spec/homebrew/services_cli_spec.rb
+++ b/spec/homebrew/services_cli_spec.rb
@@ -52,6 +52,15 @@ describe Service::ServicesCli do
       expect(Service::System).not_to receive(:root?)
       services_cli.run([])
     end
+
+    it "checks if target service has already been started and suggests restart instead" do
+      expect(Service::System).not_to receive(:root?)
+      expected_output = "Service `example_service` already started, use `brew services restart example_service` to restart.\n"
+      service = instance_double("service", :name => "example_service", :pid? => true)
+      expect do
+        services_cli.start([service])
+      end.to output(expected_output).to_stdout
+    end
   end
 
   describe "#start" do
@@ -65,6 +74,15 @@ describe Service::ServicesCli do
     it "checks empty targets cause no error" do
       expect(Service::System).not_to receive(:root?)
       services_cli.start([])
+    end
+
+    it "checks if target service has already been started and suggests restart instead" do
+      expect(Service::System).not_to receive(:root?)
+      expected_output = "Service `example_service` already started, use `brew services restart example_service` to restart.\n"
+      service = instance_double("service", :name => "example_service", :pid? => true)
+      expect do
+        services_cli.start([service])
+      end.to output(expected_output).to_stdout
     end
   end
 

--- a/spec/homebrew/services_cli_spec.rb
+++ b/spec/homebrew/services_cli_spec.rb
@@ -54,8 +54,8 @@ describe Service::ServicesCli do
     end
 
     it "checks if target service is already running and suggests restart instead" do
-      expected_output = "Service `example_service` already running," +
-        " use `brew services restart example_service` to restart.\n"
+      expected_output = "Service `example_service` already running," \
+                        " use `brew services restart example_service` to restart.\n"
       service = instance_double("service", name: "example_service", pid?: true)
       expect do
         services_cli.run([service])
@@ -77,8 +77,8 @@ describe Service::ServicesCli do
     end
 
     it "checks if target service has already been started and suggests restart instead" do
-      expected_output = "Service `example_service` already started," +
-        " use `brew services restart example_service` to restart.\n"
+      expected_output = "Service `example_service` already started," \
+                        " use `brew services restart example_service` to restart.\n"
       service = instance_double("service", name: "example_service", pid?: true)
       expect do
         services_cli.start([service])

--- a/spec/homebrew/services_cli_spec.rb
+++ b/spec/homebrew/services_cli_spec.rb
@@ -53,7 +53,7 @@ describe Service::ServicesCli do
       services_cli.run([])
     end
 
-    it "checks if target service has already been started and suggests restart instead" do
+    it "checks if target service is already running and suggests restart instead" do
       expected_output = "Service `example_service` already running, use `brew services restart example_service` to restart.\n"
       service = instance_double("service", :name => "example_service", :pid? => true)
       expect do

--- a/spec/homebrew/services_cli_spec.rb
+++ b/spec/homebrew/services_cli_spec.rb
@@ -54,11 +54,10 @@ describe Service::ServicesCli do
     end
 
     it "checks if target service has already been started and suggests restart instead" do
-      expect(Service::System).not_to receive(:root?)
-      expected_output = "Service `example_service` already started, use `brew services restart example_service` to restart.\n"
+      expected_output = "Service `example_service` already running, use `brew services restart example_service` to restart.\n"
       service = instance_double("service", :name => "example_service", :pid? => true)
       expect do
-        services_cli.start([service])
+        services_cli.run([service])
       end.to output(expected_output).to_stdout
     end
   end
@@ -77,7 +76,6 @@ describe Service::ServicesCli do
     end
 
     it "checks if target service has already been started and suggests restart instead" do
-      expect(Service::System).not_to receive(:root?)
       expected_output = "Service `example_service` already started, use `brew services restart example_service` to restart.\n"
       service = instance_double("service", :name => "example_service", :pid? => true)
       expect do


### PR DESCRIPTION
This is a one line fix for a bug in the implementation of the ServicesCli.start() function.

The code on line 89 used a reject statement which made the if statement starting on line 90 unreachable. I removed that. Additionally, I added test cases to make sure this works correctly in the ServicesCli.start() and ServicesCli.run() functions (the ServicesCli.run() function was already working correctly but lacked a test case).

Since this is a really small bug fix, I decided to just make PR instead of creating an issue. I hope that's okay.