### PR TITLE
Removed unnecessary punctuation from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Homebrew Services
 
-Manage background services using the daemon manager `launchctl` on macOS' or `systemctl` on Linux.
+Manage background services using the daemon manager `launchctl` on macOS or `systemctl` on Linux.
 
 ## Requirements
 


### PR DESCRIPTION
This is the smallest PR ever created. It just removes the now unnecessary single quote from the readme as mentioned in [#460](https://github.com/Homebrew/homebrew-services/issues/459#issuecomment-1058923011) and [#459](https://github.com/Homebrew/homebrew-services/pull/460#discussion_r819339834). I kind of feel bad that the CI/CD pipeline is gonna run after I create this.