### PR TITLE
Bug fix for loop that would never run more than once

### DIFF
--- a/lib/service/services_cli.rb
+++ b/lib/service/services_cli.rb
@@ -157,7 +157,7 @@ module Service
       quiet_system System.launchctl, "kill", "SIGTERM", "#{System.domain_target}/#{service.service_name}"
       while service.loaded?
         sleep(5)
-        break if service.loaded?
+        break unless service.loaded?
 
         quiet_system System.launchctl, "kill", "SIGKILL", "#{System.domain_target}/#{service.service_name}"
       end


### PR DESCRIPTION
Just a small loop bug that I found in the ServicesCli.kill() function.