### PR TITLE
Make `brew services stop` behave the same on linux and mac

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,7 @@ jobs:
       run: |
         brew services stop redis
         sleep 5
-        if launchctl list | grep redis; then false; else true; fi
+        brew services list | grep redis | grep none
 
     - name: Test run command
       run: |

--- a/lib/service/formula_wrapper.rb
+++ b/lib/service/formula_wrapper.rb
@@ -98,7 +98,7 @@ module Service
         # TODO: find replacement for deprecated "list"
         quiet_system System.launchctl, "list", service_name
       elsif System.systemctl?
-        quiet_system System.systemctl, System.systemctl_scope, "list-unit-files", service_file.basename
+        quiet_system System.systemctl, System.systemctl_scope, "status", service_file.basename
       end
     end
 

--- a/lib/service/services_cli.rb
+++ b/lib/service/services_cli.rb
@@ -113,7 +113,7 @@ module Service
       end
     end
 
-    # Stop a service and unregister it.
+    # Stop a service and unload it.
     def stop(targets, verbose: false)
       targets.each do |service|
         unless service.loaded?
@@ -139,10 +139,13 @@ module Service
             quiet_system System.launchctl, "bootout", "#{System.domain_target}/#{service.service_name}"
           end
           quiet_system System.launchctl, "stop", "#{System.domain_target}/#{service.service_name}" if service.pid?
-          rm service.dest if service.dest.exist?
         end
 
-        if service.pid?
+        rm service.dest if service.dest.exist?
+        # Run daemon-reload on systemctl to finish unloading stopped and deleted service.
+        safe_system System.systemctl, System.systemctl_scope, "daemon-reload" if System.systemctl?
+
+        if service.pid? || service.loaded?
           opoo "Unable to stop `#{service.name}` (label: #{service.service_name})"
         else
           ohai "Successfully stopped `#{service.name}` (label: #{service.service_name})"
@@ -253,6 +256,9 @@ module Service
         file = enable ? service.dest : service.service_file
         launchctl_load(service, file: file, enable: enable)
       elsif System.systemctl?
+        # Systemctl loads based upon location so only install service
+        # file when it is not installed. Used with the `run` command.
+        install_service_file(service, nil) unless service.dest.exist?
         systemd_load(service, enable: enable)
       end
 

--- a/spec/homebrew/services_cli_spec.rb
+++ b/spec/homebrew/services_cli_spec.rb
@@ -205,7 +205,8 @@ describe Service::ServicesCli do
       expect(Service::System).to receive(:root?).exactly(2).and_return(false)
       expect do
         services_cli.service_load(
-          OpenStruct.new(name: "name", service_name: "service.name", service_startup?: false), enable: false
+          OpenStruct.new(name: "name", service_name: "service.name", service_startup?: false,
+                         dest: OpenStruct.new(exist?: true)), enable: false
         )
       end.to output("Successfully ran `name` (label: service.name)\n").to_stdout
     end
@@ -218,7 +219,8 @@ describe Service::ServicesCli do
       expect(Service::System).to receive(:root?).exactly(2).and_return(false)
       expect do
         services_cli.service_load(
-          OpenStruct.new(name: "name", service_name: "service.name", service_startup?: false), enable: true
+          OpenStruct.new(name: "name", service_name: "service.name", service_startup?: false,
+                         dest: OpenStruct.new(exist?: true)), enable: true
         )
       end.to output("Successfully started `name` (label: service.name)\n").to_stdout
     end


### PR DESCRIPTION
Okay, I think I figured it out. This is related to issue #469.

Basically, the linux and mac versions of the `brew services stop` command behaved differently in no small part because the ServicesCli#loaded? command was always returning true on linux.

Now both of them stop, unregister and unload the service. Before the linux services would stay loaded. This meant having to change the behavior of ServicesCli#service_load to install the systemctl service file if it doesn't exist which didn't happen before with the `brew services run` command.

And now the functional test workflow has been updated to reflect the fact that stopped services should return `service-name none` when using the `brew services list` command.