### PR TITLE
Service file warnings and Restart Cmd Refactor

### DIFF
--- a/cmd/services.rb
+++ b/cmd/services.rb
@@ -39,7 +39,7 @@ module Homebrew
         [`sudo`] `brew services cleanup`:
         Remove all unused services.
       EOS
-      flag "--file=", description: "Use the plist file from this location to `start` the service."
+      flag "--file=", description: "Use the service file from this location to `start` the service."
       switch "--all", description: "Run <subcommand> on all services."
       switch "--json", description: "Output as JSON."
     end
@@ -76,6 +76,12 @@ module Homebrew
       raise UsageError, "The `#{subcommand}` subcommand does not accept a formula argument!" if formula
       raise UsageError, "The `#{subcommand}` subcommand does not accept the --all argument!" if args.all?
     end
+
+    if Service::Commands::Start::TRIGGERS.include?(subcommand) && args.all? && args.file.present?
+      raise UsageError, "The start subcommand does not accept the --all and --file= arguments at the same time!"
+    end
+
+    opoo "The --all argument overrides provided formula argument!" if formula.present? && args.all?
 
     targets = if args.all?
       Service::Formulae.available_services

--- a/cmd/services.rb
+++ b/cmd/services.rb
@@ -24,7 +24,7 @@ module Homebrew
         [`sudo`] `brew services run` (<formula>|`--all`):
         Run the service <formula> without registering to launch at login (or boot).
 
-        [`sudo`] `brew services start` (<formula>|`--all`):
+        [`sudo`] `brew services start` (<formula>|`--all`|`--file=`):
         Start the service <formula> immediately and register it to launch at login (or boot).
 
         [`sudo`] `brew services stop` (<formula>|`--all`):
@@ -39,7 +39,7 @@ module Homebrew
         [`sudo`] `brew services cleanup`:
         Remove all unused services.
       EOS
-      flag "--file=", description: "Use the plist file from this location to `start` or `run` the service."
+      flag "--file=", description: "Use the plist file from this location to `start` the service."
       switch "--all", description: "Run <subcommand> on all services."
       switch "--json", description: "Output as JSON."
     end

--- a/lib/service/commands/restart.rb
+++ b/lib/service/commands/restart.rb
@@ -7,8 +7,10 @@ module Service
 
       TRIGGERS = %w[restart relaunch reload r].freeze
 
-      def run(targets, _custom_plist, verbose:)
+      def run(targets, custom_plist, verbose:)
         return unless ServicesCli.check(targets)
+
+        odeprecated "the restart command with a service file" if custom_plist.present?
 
         ran = []
         started = []

--- a/lib/service/services_cli.rb
+++ b/lib/service/services_cli.rb
@@ -79,6 +79,9 @@ module Service
     # Start a service.
     def start(targets, service_file = nil, verbose: false)
       if service_file.present?
+        raise UsageError, "Adding custom service files is not supported on linux." if System.systemctl?
+        raise UsageError, "The --all and --file= options cannot be used together." if targets.size != 1
+
         file = Pathname.new service_file
         raise UsageError, "Provided service file does not exist" unless file.exist?
       end
@@ -109,7 +112,6 @@ module Service
         next if take_root_ownership(service).nil? && System.root?
 
         service_load(service, enable: true)
-        @service_file = nil
       end
     end
 

--- a/spec/homebrew/commands/restart_spec.rb
+++ b/spec/homebrew/commands/restart_spec.rb
@@ -17,26 +17,19 @@ describe Service::Commands::Restart do
     end
 
     it "starts if services are not loaded" do
-      expect(Service::ServicesCli).not_to receive(:run)
-      expect(Service::ServicesCli).not_to receive(:stop)
       expect(Service::ServicesCli).to receive(:start).once
-      service = OpenStruct.new(service_name: "name", loaded?: false)
+      expect(Service::ServicesCli).not_to receive(:service_restart)
+      service = OpenStruct.new(loaded?: false)
+
       expect(described_class.run([service], nil, verbose: false)).to be_nil
     end
 
-    it "starts if services are loaded with file" do
-      expect(Service::ServicesCli).not_to receive(:run)
-      expect(Service::ServicesCli).to receive(:start).once
-      expect(Service::ServicesCli).to receive(:stop).once
-      service = OpenStruct.new(service_name: "name", loaded?: true, service_file_present?: true)
-      expect(described_class.run([service], nil, verbose: false)).to be_nil
-    end
-
-    it "runs if services are loaded without file" do
+    it "restarts if services are loaded" do
       expect(Service::ServicesCli).not_to receive(:start)
-      expect(Service::ServicesCli).to receive(:run).once
-      expect(Service::ServicesCli).to receive(:stop).once
-      service = OpenStruct.new(service_name: "name", loaded?: true, service_file_present?: false)
+      expect(Service::ServicesCli).to receive(:service_restart).once.and_return(true)
+      allow(described_class).to receive(:ohai).with(an_instance_of(String)).once
+      service = OpenStruct.new(name: "name", service_name: "service_name", loaded?: true)
+
       expect(described_class.run([service], nil, verbose: false)).to be_nil
     end
   end

--- a/spec/homebrew/services_cli_spec.rb
+++ b/spec/homebrew/services_cli_spec.rb
@@ -67,7 +67,7 @@ describe Service::ServicesCli do
     it "checks missing file causes error" do
       expect(Service::System).not_to receive(:root?)
       expect do
-        services_cli.start([], "/hfdkjshksdjhfkjsdhf/fdsjghsdkjhb")
+        services_cli.start(["service_name"], "/hfdkjshksdjhfkjsdhf/fdsjghsdkjhb")
       end.to raise_error UsageError, "Provided service file does not exist"
     end
 
@@ -223,6 +223,22 @@ describe Service::ServicesCli do
                          dest: OpenStruct.new(exist?: true)), enable: true
         )
       end.to output("Successfully started `name` (label: service.name)\n").to_stdout
+    end
+  end
+
+  describe "#service_restart" do
+    it "checks systemctl version" do
+      expect(Service::System).to receive(:systemctl?).once.and_return(true)
+      expect(Service::System).to receive(:systemctl_scope).once
+      described_class.service_restart(OpenStruct.new(service_name: "name"))
+    end
+
+    it "checks launchctl version" do
+      expect(Service::System).to receive(:systemctl?).once.and_return(false)
+      expect(Service::System).to receive(:launchctl?).once.and_return(true)
+      expect(Service::System).to receive(:launchctl).once
+      expect(Service::System).to receive(:domain_target).once
+      described_class.service_restart(OpenStruct.new(service_name: "name"))
     end
   end
 end


### PR DESCRIPTION
This PR includes three things: additional warnings and usage errors, updated documentation, and a refactored restart command. The first two are pretty obvious from looking the code but the third one might not be so I'll explain it.

Essentially, the previous restart command called stop and then either start or run internally. The stop command always removes the service file. Then, the default generated service file is used to start up the service again. So essentially that custom service file would get overwritten with the default generated version which is not ideal. Instead, it now uses the internal systemctl and launchctl restart commands, which don't overwrite the service file, and defers to the start command if the service isn't loaded. Because that calls out to systemctl and launchctl most of the logic got moved from restart.rb to the restart method in services_cli.rb.

Closes #472. 