### PR TITLE
Restore old restart command

### DIFF
--- a/lib/service/services_cli.rb
+++ b/lib/service/services_cli.rb
@@ -265,15 +265,6 @@ module Service
       ohai("Successfully #{function} `#{service.name}` (label: #{service.service_name})")
     end
 
-    # Restart an already loaded service.
-    def service_restart(service)
-      if System.systemctl?
-        quiet_system System.systemctl, System.systemctl_scope, "restart", service.service_name
-      elsif System.launchctl?
-        quiet_system System.launchctl, "kickstart", "-k", "#{System.domain_target}/#{service.service_name}"
-      end
-    end
-
     def install_service_file(service, file)
       odie "Formula `#{service.name}` is not installed" unless service.installed?
 

--- a/spec/homebrew/commands/restart_spec.rb
+++ b/spec/homebrew/commands/restart_spec.rb
@@ -17,19 +17,26 @@ describe Service::Commands::Restart do
     end
 
     it "starts if services are not loaded" do
+      expect(Service::ServicesCli).not_to receive(:run)
+      expect(Service::ServicesCli).not_to receive(:stop)
       expect(Service::ServicesCli).to receive(:start).once
-      expect(Service::ServicesCli).not_to receive(:service_restart)
-      service = OpenStruct.new(loaded?: false)
-
+      service = OpenStruct.new(service_name: "name", loaded?: false)
       expect(described_class.run([service], nil, verbose: false)).to be_nil
     end
 
-    it "restarts if services are loaded" do
-      expect(Service::ServicesCli).not_to receive(:start)
-      expect(Service::ServicesCli).to receive(:service_restart).once.and_return(true)
-      allow(described_class).to receive(:ohai).with(an_instance_of(String)).once
-      service = OpenStruct.new(name: "name", service_name: "service_name", loaded?: true)
+    it "starts if services are loaded with file" do
+      expect(Service::ServicesCli).not_to receive(:run)
+      expect(Service::ServicesCli).to receive(:start).once
+      expect(Service::ServicesCli).to receive(:stop).once
+      service = OpenStruct.new(service_name: "name", loaded?: true, service_file_present?: true)
+      expect(described_class.run([service], nil, verbose: false)).to be_nil
+    end
 
+    it "runs if services are loaded without file" do
+      expect(Service::ServicesCli).not_to receive(:start)
+      expect(Service::ServicesCli).to receive(:run).once
+      expect(Service::ServicesCli).to receive(:stop).once
+      service = OpenStruct.new(service_name: "name", loaded?: true, service_file_present?: false)
       expect(described_class.run([service], nil, verbose: false)).to be_nil
     end
   end

--- a/spec/homebrew/services_cli_spec.rb
+++ b/spec/homebrew/services_cli_spec.rb
@@ -227,20 +227,4 @@ describe Service::ServicesCli do
       end.to output("Successfully started `name` (label: service.name)\n").to_stdout
     end
   end
-
-  describe "#service_restart" do
-    it "checks systemctl version" do
-      expect(Service::System).to receive(:systemctl?).once.and_return(true)
-      expect(Service::System).to receive(:systemctl_scope).once
-      described_class.service_restart(OpenStruct.new(service_name: "name"))
-    end
-
-    it "checks launchctl version" do
-      expect(Service::System).to receive(:systemctl?).once.and_return(false)
-      expect(Service::System).to receive(:launchctl?).once.and_return(true)
-      expect(Service::System).to receive(:launchctl).once
-      expect(Service::System).to receive(:domain_target).once
-      described_class.service_restart(OpenStruct.new(service_name: "name"))
-    end
-  end
 end


### PR DESCRIPTION
This restores the old restart command as discussed so that it can be used to update service files after upgrading formulas. I added a note to the `restart.rb` file mentioning the intended behavior but I'm not exactly sure how to add tests so this sort of thing doesn't happen again in the future.

The first thing that comes to mind would be to add a functional test that checks to make sure that the service file was updated/overwritten after the call to `brew services restart`. Finding a cross platform way to do that and reconciling the different locations of the services files on macOS and linux is probably beyond me to be honest.

Either way this PR should fix the immediate problem.