### PR TITLE
Added support for running services fully backgrounded on macOS

### DIFF
--- a/lib/service/services_cli.rb
+++ b/lib/service/services_cli.rb
@@ -272,12 +272,36 @@ module Service
         odie "Formula `#{service.name}` has not implemented #plist, #service or installed a locatable service file"
       end
 
-      temp = Tempfile.new(service.service_name)
-      temp << if file.blank?
+      data = if file.blank?
         service.service_file.read
       else
         file.read
       end
+
+      if System.launchctl?
+        plist = begin
+          Plist.parse_xml(data)
+        rescue
+          nil
+        end
+        odie "Unable to parse plist for service `#{service.name}`" unless plist
+
+        # If the key is merely present then we can already skip adding it ourselves:
+        # * If somehow the plist already comes with this key by default then we won't touch it
+        # * If it exists but it's empty that *might* be on purpose, so again won't touch it
+        # * Otherwise we'll just add all known session types so the service can start regardless of what it is
+        #
+        # Adding all session types also means that if you initialise it through e.g. a Background session and you later "physically"
+        # sign in to the owning account (Aqua session), things shouldn't flip out
+        limit_sessiontype = plist["LimitLoadToSessionType"]&.first
+        unless limit_sessiontype.present?
+          plist["LimitLoadToSessionType"] = ["Aqua", "Background", "LoginWindow", "StandardIO", "System"]
+          data = plist.to_plist
+        end
+      end
+
+      temp = Tempfile.new(service.service_name)
+      temp << data
       temp.flush
 
       rm service.dest if service.dest.exist?

--- a/lib/service/system.rb
+++ b/lib/service/system.rb
@@ -76,7 +76,7 @@ module Service
       if root?
         "system"
       else
-        "gui/#{Process.uid}"
+        "user/#{Process.uid}"
       end
     end
   end

--- a/spec/homebrew/system_spec.rb
+++ b/spec/homebrew/system_spec.rb
@@ -75,7 +75,7 @@ describe Service::System do
   describe "#domain_target" do
     it "returns the current domain target" do
       allow(described_class).to receive(:root?).and_return(false)
-      expect(described_class.domain_target).to match(%r{gui/(\d+)})
+      expect(described_class.domain_target).to match(%r{user/(\d+)})
     end
 
     it "returns the root domain target" do


### PR DESCRIPTION
This PR is the product of a discussion on the [main Homebrew repo](https://github.com/Homebrew/discussions/discussions/3253). In short: it aims to improve working with `brew services` on multi-user systems when sharing a global HB instance, although there is also some benefit for single-user systems (see the next section).

Besides changing the `gui/*` domain to `user/*` stuff, HB now also modifies every plist it installs (or checks if it has to, at least). I've explained that last part in comments next to the relevant code, so I'm not going to repeat it here. It's not a very large patch anyway. :> The `user` domain seems to always be present as long as some form of login occurred, it can also co-exist with `gui`. And since `homebrew-services` is specifically meant for **background** services it also makes the most sense to just use `user` domains.

The session types aren't explained there, but I found them [here](https://stackoverflow.com/a/10576897/8132412):
> * Aqua: a GUI agent; has access to all the GUI services
> * LoginWindow: pre-login agent; runs in the login window context
> * Background: runs in the parent context of the user
> * StandardIO: runs only in non-GUI login session (e.g. SSH sessions)
>
> I could guess about System, but then so could you.

Just for reference, if you wanted to check the current session type, just run `launchctl managername` and it'll print any of those names.

---

### Some important usage/background information

Although it requires a specific setup, many parts are already recommended for/relevant to multi-user systems even without this patch:
1. You need a dedicated user account for managing HB, which is already [recommended in the HB FAQ](https://docs.brew.sh/FAQ#why-does-homebrew-say-sudo-is-bad).
2. If you want to be able to just run `brew` as a non-HB user, you'll need an alias/shell function, which you'd already need without the patch too. In my case I also want to be able to run `brew` without having to type the other account's password every time. An example:
```
brew() {
	sudo su -l mybrew -c "source \$HOME/.bash_profile; brew $*"
}
```

Then `/etc/sudoers.d/homebrew` contains simply `myuser ALL=NOPASSWD: /usr/bin/su -l mybrew -c *`, meaning my own account can run any commands as `mybrew` no prob.

Note how I'm doing `sudo su` instead of just `sudo` or `su`, the latter of which doesn't even pass through sudoers config so using it stand-alone would always require typing a password. Furthermore, there's a major problem with just using `sudo` because it either doesn't set up the environment for the target user, or (and this is the important part relevant for this patch) **launchctl detects the wrong login session type** and the service won't even start. `brew` will report it did but it's actually hanging on the `bootstrap` command and you have to `launchctl bootout user/<UID> <service name>` to get it unstuck. Like I'm doing in the example you can't actually pass multiple commands directly to `sudo` without using e.g. `sudo -u mybrew bash -c "multiple; commands; here"`. Using `sudo` with any shell like that will cause launchctl to detect an `Aqua` session, although I've only checked with `bash` and `sh` there might be shell-specific overrides. Finally, I'm using `su -l` to discard the current environment, which again is needed to get it detected as a `Background` session. That also means I have to manually `source` the target user's shell config, since I have some HB-related environment variables in there and I need them exported for the `brew` command. Pretty sure `sudo` simply overrides the "interactivity" of `su`'s shell and causes it to no longer read profiles automatically, but instead goes looking for an environment variable `BASH_ENV` (or `ENV` for `sh`). May as well just source the file directly then. =]

With this setup you can run `brew services` commands as any user and the service will be able to start regardless of whether you're in an actual GUI/Aqua session or doing some `su(do)` magic. It also doesn't break things for anyone with a single-user setup; if anything it also **improves** it for them, e.g. starting a service purely through SSH should also be possible now.

And a final note: keep in mind that although HB installs a LaunchAgent that **would normally** autostart the service when rebooting, it won't actually trigger if you're not logging on to an Aqua session for the dedicated user. So you'll always have to manually run a `start` command, or write a LaunchAgent for your own user that runs the necessary `brew` commands. It probably **could** autostart if you were to put the plist in the system `/Library` and have it run in `LoginWindow` or even `System` context. But then `brew` itself needs to `sudo` up and that goes against Homebrew's ideas. :D