### PR TITLE
systemd: support systemctl --user without dbus

### DIFF
--- a/cmd/services.rb
+++ b/cmd/services.rb
@@ -93,6 +93,7 @@ module Homebrew
 
     if Service::System.systemctl?
       ENV["DBUS_SESSION_BUS_ADDRESS"] = ENV.fetch("HOMEBREW_DBUS_SESSION_BUS_ADDRESS", nil)
+      ENV["XDG_RUNTIME_DIR"] = ENV.fetch("HOMEBREW_XDG_RUNTIME_DIR", nil)
     end
 
     # Dispatch commands and aliases.


### PR DESCRIPTION
Pass along the `XDG_RUNTIME_DIR` so systemctl --user can fall back to it's
internal dbus socket; needed when no user-session dbus daemon is installed.

Depends on Homebrew/brew#13686 to be merged for `HOMEBREW_XDG_RUNTIME_DIR` to
exist.

Fixes #496
