### PR TITLE
Added support for running services fully backgrounded on macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,7 +133,7 @@ jobs:
       run: |
         plist=$(brew services info redis --verbose | grep ^File: | awk '{print $2}')
         echo "Base plist: $plist"
-        sed -i '' '/LimitLoadToSessionTypeZ/,+7d' "$plist"
+        sed -i '' '/LimitLoadToSessionType/,+7d' "$plist"
         brew services start redis
 
         plist=$(brew services info redis --verbose | grep ^File: | awk '{print $2}')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,7 +132,7 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         plist=$(brew services info redis --verbose | grep ^File: | awk '{print $2}')
-        sed -i '/LimitLoadToSessionTypeZ/,+7d' "$plist"
+        sed -i '' '/LimitLoadToSessionTypeZ/,+7d' "$plist"
         ! grep -q LimitLoadToSessionType "$plist"
         brew services start redis
         brew services stop redis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: master
+    branches: [master, test]
   pull_request:
 jobs:
   tap_syntax:
@@ -127,3 +127,13 @@ jobs:
         brew services info redis | grep redis
         brew services info redis --verbose | grep redis
         brew services info redis --json | ruby -e "require 'json'" -e "puts JSON.parse(ARGF.read)"
+
+    - name: Rewrite plist to old style and recheck start/stop commands (macOS only)
+      if: matrix.os == 'macos-latest'
+      run: |
+        plist=$(brew services info redis --verbose | grep ^File: | awk '{print $2}')
+        sed -i '/LimitLoadToSessionTypeZ/,+7d' "$plist"
+        ! grep -q LimitLoadToSessionType "$plist"
+        brew services start redis
+        brew services stop redis
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master, test]
+    branches: [master]
   pull_request:
 jobs:
   tap_syntax:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,7 +133,7 @@ jobs:
       run: |
         plist=$(brew services info redis --verbose | grep ^File: | awk '{print $2}')
         echo "Base plist: $plist"
-        sed -i '' '/LimitLoadToSessionType/,+7d' "$plist"
+        sed -i '' '/LimitLoadToSessionTypeZ/,+7d' "$plist"
         brew services start redis
 
         plist=$(brew services info redis --verbose | grep ^File: | awk '{print $2}')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: master
   pull_request:
 jobs:
   tap_syntax:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,9 +132,12 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         plist=$(brew services info redis --verbose | grep ^File: | awk '{print $2}')
-        echo "Plist: $plist"
-        sed -i '' '/LimitLoadToSessionTypeZ/,+7d' "$plist"
-        grep -q LimitLoadToSessionType "$plist" && exit 1
+        echo "Base plist: $plist"
+        sed -i '' '/LimitLoadToSessionType/,+7d' "$plist"
         brew services start redis
+
+        plist=$(brew services info redis --verbose | grep ^File: | awk '{print $2}')
+        echo "Installed plist: $plist"
+        grep -A 7 LimitLoadToSessionType "$plist" && exit 1
         brew services stop redis
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,8 +132,9 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         plist=$(brew services info redis --verbose | grep ^File: | awk '{print $2}')
+        echo "Plist: $plist"
         sed -i '' '/LimitLoadToSessionTypeZ/,+7d' "$plist"
-        ! grep -q LimitLoadToSessionType "$plist"
+        grep -q LimitLoadToSessionType "$plist" && exit 1
         brew services start redis
         brew services stop redis
 

--- a/lib/service/services_cli.rb
+++ b/lib/service/services_cli.rb
@@ -132,12 +132,13 @@ module Service
         if System.systemctl?
           quiet_system System.systemctl, System.systemctl_scope, "disable", "--now", service.service_name
         elsif System.launchctl?
-          quiet_system System.launchctl, "bootout", "#{System.domain_target}/#{service.service_name}"
+          domain = System.domain_target(service)
+          quiet_system System.launchctl, "bootout", "#{domain}/#{service.service_name}"
           while $CHILD_STATUS.to_i == 9216 || service.loaded?
             sleep(1)
-            quiet_system System.launchctl, "bootout", "#{System.domain_target}/#{service.service_name}"
+            quiet_system System.launchctl, "bootout", "#{domain}/#{service.service_name}"
           end
-          quiet_system System.launchctl, "stop", "#{System.domain_target}/#{service.service_name}" if service.pid?
+          quiet_system System.launchctl, "stop", "#{domain}/#{service.service_name}" if service.pid?
         end
 
         rm service.dest if service.dest.exist?
@@ -164,7 +165,7 @@ module Service
           if System.systemctl?
             quiet_system System.systemctl, System.systemctl_scope, "stop", service.service_name
           elsif System.launchctl?
-            quiet_system System.launchctl, "stop", "#{System.domain_target}/#{service.service_name}"
+            quiet_system System.launchctl, "stop", "#{System.domain_target(service)}/#{service.service_name}"
           end
 
           if service.pid?
@@ -241,8 +242,9 @@ module Service
     end
 
     def launchctl_load(service, file:, enable:)
-      safe_system System.launchctl, "enable", "#{System.domain_target}/#{service.service_name}" if enable
-      safe_system System.launchctl, "bootstrap", System.domain_target, file
+      domain = System.domain_target(service)
+      safe_system System.launchctl, "enable", "#{domain}/#{service.service_name}" if enable
+      safe_system System.launchctl, "bootstrap", domain, file
     end
 
     def systemd_load(service, enable:)

--- a/lib/service/system.rb
+++ b/lib/service/system.rb
@@ -72,9 +72,21 @@ module Service
       root? ? boot_path : user_path
     end
 
-    def domain_target
+    def domain_target_needs_background?(service)
+      plist_data = service.generate_plist(nil)
+      plist = begin
+        Plist.parse_xml(plist_data)
+      rescue
+        nil
+      end
+      !plist.nil? && !plist["LimitLoadToSessionType"].nil?
+    end
+
+    def domain_target(service)
       if root?
         "system"
+      elsif domain_target_needs_background?(service)
+        "user/#{Process.uid}"
       else
         "gui/#{Process.uid}"
       end

--- a/lib/service/system.rb
+++ b/lib/service/system.rb
@@ -73,13 +73,15 @@ module Service
     end
 
     def domain_target_needs_background?(service)
+      # We need to parse the current plist verbatim and the generate_plist() function already figures out where it is,
+      # so no need to pass any data ourselves
       plist_data = service.generate_plist(nil)
       plist = begin
         Plist.parse_xml(plist_data)
       rescue
         nil
       end
-      !plist.nil? && !plist["LimitLoadToSessionType"].nil?
+      plist.present? && plist["LimitLoadToSessionType"].present?
     end
 
     def domain_target(service)

--- a/lib/service/system.rb
+++ b/lib/service/system.rb
@@ -74,11 +74,15 @@ module Service
 
     def domain_target_needs_background?(service)
       # We need to parse the current plist verbatim and the generate_plist() function already figures out where it is,
-      # so no need to pass any data ourselves
+      # so no need to pass any data ourselves.
       plist_data = service.generate_plist(nil)
       plist = begin
         Plist.parse_xml(plist_data)
-      rescue
+      rescue RuntimeError, UnimplementedElementError
+        # Parsing the plist could fail with a RuntimeError because it may not recognise some tags, or it handles
+        # an exception itself and returns nil instead. It could also raise an UnimplementedElementError, depending
+        # on where the error occurred.
+        # Either way, setting our fallback value to nil allows for a simple check at the end.
         nil
       end
       plist.present? && plist["LimitLoadToSessionType"].present?

--- a/spec/homebrew/services_cli_spec.rb
+++ b/spec/homebrew/services_cli_spec.rb
@@ -156,7 +156,7 @@ describe Service::ServicesCli do
     end
 
     it "checks enabling run" do
-      expect(Service::System).to receive(:domain_target).exactly(2).and_return("target")
+      expect(Service::System).to receive(:domain_target).exactly(1).and_return("target")
       expect(Service::System).to receive(:launchctl).exactly(2).and_return("/bin/launchctl")
       services_cli.launchctl_load(OpenStruct.new(service_name: "name"), file: "a", enable: true)
     end

--- a/spec/homebrew/system_spec.rb
+++ b/spec/homebrew/system_spec.rb
@@ -73,14 +73,25 @@ describe Service::System do
   end
 
   describe "#domain_target" do
-    it "returns the current domain target" do
-      allow(described_class).to receive(:root?).and_return(false)
-      expect(described_class.domain_target).to match(%r{(?:gui|user)/(\d+)})
+    let(:service) do
+      OpenStruct.new(name: "name", installed?: true, service_file: OpenStruct.new(file?: Pathname.new("/tmp_home/Library/LaunchAgents/homebrew.mysql.plist")))
     end
 
     it "returns the root domain target" do
       allow(described_class).to receive(:root?).and_return(true)
-      expect(described_class.domain_target).to match("system")
+      expect(described_class.domain_target(service)).to match("system")
+    end
+
+    it "returns the current domain target for sessions with background support" do
+      allow(described_class).to receive(:root?).and_return(false)
+      allow(described_class).to receive(:domain_target_needs_background?).and_return(true)
+      expect(described_class.domain_target(service)).to match(%r{user/(\d+)})
+    end
+
+    it "returns the current domain target" do
+      allow(described_class).to receive(:root?).and_return(false)
+      allow(described_class).to receive(:domain_target_needs_background?).and_return(false)
+      expect(described_class.domain_target(service)).to match(%r{gui/(\d+)})
     end
   end
 

--- a/spec/homebrew/system_spec.rb
+++ b/spec/homebrew/system_spec.rb
@@ -75,8 +75,8 @@ describe Service::System do
   describe "#domain_target" do
     let(:service) do
       OpenStruct.new(
-        name: "name",
-        installed?: true,
+        name:         "name",
+        installed?:   true,
         service_file: OpenStruct.new(file?: Pathname.new("/tmp_home/Library/LaunchAgents/homebrew.mysql.plist")),
       )
     end

--- a/spec/homebrew/system_spec.rb
+++ b/spec/homebrew/system_spec.rb
@@ -74,7 +74,11 @@ describe Service::System do
 
   describe "#domain_target" do
     let(:service) do
-      OpenStruct.new(name: "name", installed?: true, service_file: OpenStruct.new(file?: Pathname.new("/tmp_home/Library/LaunchAgents/homebrew.mysql.plist")))
+      OpenStruct.new(
+        name: "name",
+        installed?: true,
+        service_file: OpenStruct.new(file?: Pathname.new("/tmp_home/Library/LaunchAgents/homebrew.mysql.plist")),
+      )
     end
 
     it "returns the root domain target" do

--- a/spec/homebrew/system_spec.rb
+++ b/spec/homebrew/system_spec.rb
@@ -75,7 +75,7 @@ describe Service::System do
   describe "#domain_target" do
     it "returns the current domain target" do
       allow(described_class).to receive(:root?).and_return(false)
-      expect(described_class.domain_target).to match(%r{gui/(\d+)})
+      expect(described_class.domain_target).to match(%r{(?:gui|user)/(\d+)})
     end
 
     it "returns the root domain target" do


### PR DESCRIPTION
Re: #485

After the changes from this PR I first reverted the plist to the old state, so that it doesn't contain the `LimitLoadToSessionType` key. Then I tried to start Apache (remember, `brew` is my alias that wraps `sudo su`):
```
myuser:~$ grep LimitLoadToSessionType /opt/homebrew/opt/httpd/homebrew.mxcl.httpd.plist
myuser:~$ brew services start httpd
Could not enable service: 125: Domain does not support specified action
Error: Failure while executing; `/bin/launchctl enable gui/503/homebrew.mxcl.httpd` exited with 125.
```

This is exactly the old/original behaviour (note the `gui` domain). Just to be sure I physically logged on to `mybrew`, then:
```
mybrew:~$ grep LimitLoadToSessionType /opt/homebrew/opt/httpd/homebrew.mxcl.httpd.plist
mybrew:~$ brew services start httpd
==> Successfully started `httpd` (label: homebrew.mxcl.httpd)
```

After logging out the service gets killed, just what you'd expect since we're still on the `gui` domain.

Back to my own user:
```
myuser:~$ brew reinstall httpd
..............................
myuser:~$ grep LimitLoadToSessionType /opt/homebrew/opt/httpd/homebrew.mxcl.httpd.plist
	<key>LimitLoadToSessionType</key>
myuser:~$ brew services start httpd
==> Successfully started `httpd` (label: homebrew.mxcl.httpd)
```

---

Some notes:
1. I'm not quite sure what to do about adding a test for the old plist behaviour, since that would require a (pre-installed) plist that doesn't have the `LimitLoadToSessionType` key (yet). I could add something fixed but I don't think that's the best way.

2. I don't really like the name `domain_target_needs_background?` for the function I added but I couldn't think of something more fitting either. I could just add the code directly to `def domain_target` instead, but I wanted to keep that as minimal as possible. Also, if we're gonna keep the second function did you want it documented in the `system_spec.rb`? It's sort of an internal function though.

3. For the `domain_target` spec you had an explicit capturing group for the UID, so for distinguishing `gui` and `user` I used a non-capturing group just to be sure it doesn't interfere with anything expecting the first group to be the UID.

---

Seems like the spec tests are failing, but looking at the spec for `user_of_process` I don't see anything to specify the arguments?