### PR TITLE
pass services instead of labels to ServicesCli#kill

### DIFF
--- a/lib/service/services_cli.rb
+++ b/lib/service/services_cli.rb
@@ -37,14 +37,18 @@ module Service
     # Kill services that don't have a service file
     def kill_orphaned_services
       cleaned = []
+      cleaned_svcs = []
       running.each do |label|
         if (svc = FormulaWrapper.from(label))
-          cleaned << label unless svc.dest.file?
+          unless svc.dest.file?
+            cleaned << label
+            cleaned_svcs << svc
+          end
         else
           opoo "Service #{label} not managed by `#{bin}` => skipping"
         end
       end
-      kill(cleaned)
+      kill(cleaned_svcs)
       cleaned
     end
 

--- a/lib/service/services_cli.rb
+++ b/lib/service/services_cli.rb
@@ -36,10 +36,10 @@ module Service
 
     # Kill services that don't have a service file
     def kill_orphaned_services
-      cleaned = []
-      cleaned_svcs = []
+      cleaned_labels = []
+      cleaned_services = []
       running.each do |label|
-        if (svc = FormulaWrapper.from(label))
+        if (service = FormulaWrapper.from(label))
           unless svc.dest.file?
             cleaned << label
             cleaned_svcs << svc

--- a/lib/service/services_cli.rb
+++ b/lib/service/services_cli.rb
@@ -40,16 +40,16 @@ module Service
       cleaned_services = []
       running.each do |label|
         if (service = FormulaWrapper.from(label))
-          unless svc.dest.file?
-            cleaned << label
-            cleaned_svcs << svc
+          unless service.dest.file?
+            cleaned_labels << label
+            cleaned_services << service
           end
         else
           opoo "Service #{label} not managed by `#{bin}` => skipping"
         end
       end
-      kill(cleaned_svcs)
-      cleaned
+      kill(cleaned_services)
+      cleaned_labels
     end
 
     def remove_unused_service_files


### PR DESCRIPTION
fixes brew trying to call kill with a bunch of strings when orphaned services are found