### PR TITLE
Fix Zsh completion

### DIFF
--- a/completions/zsh/_brew_services
+++ b/completions/zsh/_brew_services
@@ -1,4 +1,4 @@
-#compdef brew
+#compdef 'brew services'
 #autoload
 
 __brew_installed_services() {


### PR DESCRIPTION
Currently, trying to get completion for `brew services` results in `a completion function is not defined for command or alias: services` and no actual completions. This is because `#compdef brew` in _brew_services conflicts with an identical statement in _brew, causing Zsh's compinit to not load _brew_services at all.

This commit fixes that by instead declaring that this file defines completion for `brew services` only.