### PR TITLE
Support (and set) `launchd` user domain target

### DIFF
--- a/lib/service/commands/list.rb
+++ b/lib/service/commands/list.rb
@@ -73,6 +73,7 @@ module Service
         when :stopped, :none then "#{Tty.default}#{status}#{Tty.reset}"
         when :error   then "#{Tty.red}error  #{Tty.reset}"
         when :unknown then "#{Tty.yellow}unknown#{Tty.reset}"
+        when :other then "#{Tty.yellow}other#{Tty.reset}"
         end
       end
     end

--- a/lib/service/formulae.rb
+++ b/lib/service/formulae.rb
@@ -9,7 +9,10 @@ module Service
     def available_services
       require "formula"
 
-      Formula.installed.map { |formula| FormulaWrapper.new(formula) }.select(&:plist?).sort_by(&:name)
+      Formula.installed
+             .map { |formula| FormulaWrapper.new(formula) }
+             .select(&:service?)
+             .sort_by(&:name)
     end
 
     # List all available services with status, user, and path to the file.

--- a/spec/homebrew/commands/list_spec.rb
+++ b/spec/homebrew/commands/list_spec.rb
@@ -129,7 +129,7 @@ describe Service::Commands::List do
     end
 
     it "returns other" do
-      expect(described_class.get_status_string(:other)).to be_nil
+      expect(described_class.get_status_string(:other)).to eq("<YELLOW>other<RESET>")
     end
   end
 end

--- a/spec/homebrew/formula_wrapper_spec.rb
+++ b/spec/homebrew/formula_wrapper_spec.rb
@@ -119,14 +119,14 @@ describe Service::FormulaWrapper do
     it "macOS - outputs if the service is loaded" do
       allow(Service::System).to receive(:launchctl?).and_return(true)
       allow(Service::System).to receive(:systemctl?).and_return(false)
-      allow(service).to receive(:quiet_system).and_return(false)
+      allow(Utils).to receive(:safe_popen_read)
       expect(service.loaded?).to be(false)
     end
 
     it "systemD - outputs if the service is loaded" do
       allow(Service::System).to receive(:launchctl?).and_return(false)
       allow(Service::System).to receive(:systemctl?).and_return(true)
-      allow(service).to receive(:quiet_system).and_return(false)
+      allow(Utils).to receive(:safe_popen_read)
       expect(service.loaded?).to be(false)
     end
 

--- a/spec/homebrew/services_cli_spec.rb
+++ b/spec/homebrew/services_cli_spec.rb
@@ -173,14 +173,12 @@ describe Service::ServicesCli do
 
   describe "#systemd_load" do
     it "checks non-enabling run" do
-      expect(Service::System).to receive(:systemctl_scope).once.and_return("--user")
-      expect(Service::System).to receive(:systemctl).once.and_return("/bin/launchctl")
+      expect(Service::System).to receive(:systemctl_args).once.and_return(["/bin/launchctl", "--user"])
       services_cli.systemd_load(OpenStruct.new(service_name: "name"), enable: false)
     end
 
     it "checks enabling run" do
-      expect(Service::System).to receive(:systemctl_scope).exactly(2).and_return("--user")
-      expect(Service::System).to receive(:systemctl).exactly(2).and_return("/bin/launchctl")
+      expect(Service::System).to receive(:systemctl_args).twice.and_return(["/bin/launchctl", "--user"])
       services_cli.systemd_load(OpenStruct.new(service_name: "name"), enable: true)
     end
   end
@@ -193,8 +191,8 @@ describe Service::ServicesCli do
     end
 
     it "checks enabling run" do
-      expect(Service::System).to receive(:domain_target).exactly(2).and_return("target")
-      expect(Service::System).to receive(:launchctl).exactly(2).and_return("/bin/launchctl")
+      expect(Service::System).to receive(:domain_target).twice.and_return("target")
+      expect(Service::System).to receive(:launchctl).twice.and_return("/bin/launchctl")
       services_cli.launchctl_load(OpenStruct.new(service_name: "name"), file: "a", enable: true)
     end
   end
@@ -215,7 +213,7 @@ describe Service::ServicesCli do
     it "checks root for startup" do
       expect(Service::System).to receive(:launchctl?).once.and_return(false)
       expect(Service::System).to receive(:systemctl?).once.and_return(false)
-      expect(Service::System).to receive(:root?).exactly(2).and_return(false)
+      expect(Service::System).to receive(:root?).twice.and_return(false)
       out = "name must be run as root to start at system startup!\nSuccessfully ran `name` (label: service.name)\n"
       expect do
         services_cli.service_load(OpenStruct.new(name: "name", service_name: "service.name", service_startup?: true),
@@ -228,7 +226,7 @@ describe Service::ServicesCli do
       expect(Service::System).to receive(:launchctl?).once.and_return(true)
       expect(Service::System).to receive(:launchctl).once
       expect(Service::System).not_to receive(:systemctl?)
-      expect(Service::System).to receive(:root?).exactly(2).and_return(false)
+      expect(Service::System).to receive(:root?).twice.and_return(false)
       expect do
         services_cli.service_load(
           OpenStruct.new(name: "name", service_name: "service.name", service_startup?: false), enable: false
@@ -239,9 +237,8 @@ describe Service::ServicesCli do
     it "triggers systemctl" do
       expect(Service::System).to receive(:launchctl?).once.and_return(false)
       expect(Service::System).to receive(:systemctl?).once.and_return(true)
-      expect(Service::System).to receive(:systemctl).once
-      expect(Service::System).to receive(:systemctl_scope).once
-      expect(Service::System).to receive(:root?).exactly(2).and_return(false)
+      expect(Service::System).to receive(:systemctl_args).once
+      expect(Service::System).to receive(:root?).twice.and_return(false)
       expect do
         services_cli.service_load(
           OpenStruct.new(name: "name", service_name: "service.name", service_startup?: false,
@@ -253,9 +250,8 @@ describe Service::ServicesCli do
     it "represents correct action" do
       expect(Service::System).to receive(:launchctl?).once.and_return(false)
       expect(Service::System).to receive(:systemctl?).once.and_return(true)
-      expect(Service::System).to receive(:systemctl).exactly(2)
-      expect(Service::System).to receive(:systemctl_scope).exactly(2)
-      expect(Service::System).to receive(:root?).exactly(2).and_return(false)
+      expect(Service::System).to receive(:systemctl_args).twice
+      expect(Service::System).to receive(:root?).twice.and_return(false)
       expect do
         services_cli.service_load(
           OpenStruct.new(name: "name", service_name: "service.name", service_startup?: false,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -137,6 +137,8 @@ module Service
     def odie(string)
       raise TestExit, string
     end
+
+    def odebug(header, string); end
   end
 
   module Commands


### PR DESCRIPTION
When running `brew services` over `ssh` or `sudo` as a non-`root` user the `gui` domain target for `launchd` does not work as expected. This produces confusing failures for users.

It was tried before to detect if this was needed from the `.plist` or changing globally but both approaches were unsuccessful/error-prone.

Instead, use the `user` domain automatically on the cases we know it's needed: when running over `ssh` or through `sudo`. To make clear to users what's happening in these cases: output a warning (which can be hidden with an output environment variable).

For this to work, `launchctl list` is no longer sufficient. The output here, even when run as `root`, does not properly list `user` domain services. Instead, we need to use `launchctl print` to correctly query the status of these services. This also seems to correctly handle some `launchd` edge-cases where launched services cannot be detected and lets `brew services` now stop them.

While we're here, fix some related issues I came upon while working on this:
- improve the `brew services` command documentation to note it now runs on Linux/`systemd` too
- use `named_args` and remove the `custom_plist` deprecation: it's been long enough and this cleans up the code nicely.
- if a service is status `:other` (an edge-case that shouldn't be possible in normal operation): actually output this rather than failing with a `nil` error
- avoid running `launchctl list` multiple times when unnecessary
- `brew services --debug` now outputs the raw output from `launchctl` or `systemctl` to aid debugging/development
- cleanup some code style and avoid use of `plist?`
- add `System.systemctl_args` to avoid repeating `System.systemctl` and `System.systemctl_scope` in every call site

--- 

Depends on https://github.com/Homebrew/brew/pull/16041 to detect `sudo` or `ssh` correctly.