### PR TITLE
Add `--sudo-service-user` flag

### DIFF
--- a/cmd/services.rb
+++ b/cmd/services.rb
@@ -40,6 +40,7 @@ module Homebrew
         Remove all unused services.
       EOS
       flag "--file=", description: "Use the service file from this location to `start` the service."
+      flag "--sudo-service-user=", description: "When run as root on macOS, run the service(s) as this user."
       switch "--all", description: "Run <subcommand> on all services."
       switch "--json", description: "Output as JSON."
     end
@@ -61,6 +62,21 @@ module Homebrew
     if !::Service::System.launchctl? && !::Service::System.systemctl?
       raise UsageError,
             "`brew services` is supported only on macOS or Linux (with systemd)!"
+    end
+
+    if (sudo_service_user = args.sudo_service_user)
+      unless ::Service::System.root?
+        raise UsageError,
+              "`brew services` is supported only when running as root!"
+      end
+
+      unless ::Service::System.launchctl?
+        raise UsageError,
+              "`brew services --sudo-service-user` is currently supported only on macOS " \
+              "(but we'd love a PR to add Linux support)!"
+      end
+
+      ::Service::ServicesCli.sudo_service_user = sudo_service_user
     end
 
     # Parse arguments.

--- a/lib/service/formula_wrapper.rb
+++ b/lib/service/formula_wrapper.rb
@@ -120,6 +120,16 @@ module Service
     end
 
     def owner
+      if System.launchctl? && dest.exist?
+        require "rexml/document"
+
+        # read the username from the plist file
+        plist = REXML::Document.new(dest.read)
+        username_xpath = "/plist/dict/key[text()='UserName']/following-sibling::*[1]"
+        plist_username = REXML::XPath.first(plist, username_xpath)&.text
+
+        return plist_username if plist_username.present?
+      end
       return "root" if boot_path_service_file_present?
       return System.user if user_path_service_file_present?
 


### PR DESCRIPTION
This flag allows setting the `UserName` for `launchd` plists when running as `root`. This means that `launchd` will drop privileges to the relevant user when starting the service.

This is significantly more secure than running services as `root` and enables a reasonable way to run systemwide services as unprivileged users.