### PR TITLE
Add `--no-wait` argument

### DIFF
--- a/cmd/services.rb
+++ b/cmd/services.rb
@@ -45,6 +45,7 @@ module Homebrew
       flag "--sudo-service-user=", description: "When run as root on macOS, run the service(s) as this user."
       switch "--all", description: "Run <subcommand> on all services."
       switch "--json", description: "Output as JSON."
+      switch "--no-wait", description: "Don't wait for `stop` to finish stopping the service."
       named_args max: 2
     end
   end
@@ -124,7 +125,7 @@ module Homebrew
     when *::Service::Commands::Start::TRIGGERS
       ::Service::Commands::Start.run(targets, args.file, verbose: args.verbose?)
     when *::Service::Commands::Stop::TRIGGERS
-      ::Service::Commands::Stop.run(targets, verbose: args.verbose?)
+      ::Service::Commands::Stop.run(targets, verbose: args.verbose?, no_wait: args.no_wait?)
     when *::Service::Commands::Kill::TRIGGERS
       ::Service::Commands::Kill.run(targets, verbose: args.verbose?)
     else

--- a/lib/service/commands/restart.rb
+++ b/lib/service/commands/restart.rb
@@ -26,11 +26,11 @@ module Service
             # group not-started services with started ones for restart
             started << service
           end
-          ServicesCli.stop([service]) if service.loaded?
+          ServicesCli.stop([service], verbose: verbose) if service.loaded?
         end
 
-        ServicesCli.run(ran) if ran.present?
-        ServicesCli.start(started) if started.present?
+        ServicesCli.run(ran, verbose: verbose) if ran.present?
+        ServicesCli.start(started, verbose: verbose) if started.present?
       end
     end
   end

--- a/lib/service/commands/stop.rb
+++ b/lib/service/commands/stop.rb
@@ -7,9 +7,9 @@ module Service
 
       TRIGGERS = %w[stop unload terminate term t u].freeze
 
-      def run(targets, verbose:)
+      def run(targets, verbose:, no_wait:)
         ServicesCli.check(targets) &&
-          ServicesCli.stop(targets, verbose: verbose)
+          ServicesCli.stop(targets, verbose: verbose, no_wait: no_wait)
       end
     end
   end


### PR DESCRIPTION
This prevents us from looping and waiting for `brew services stop` to finish stopping the service if we just want to attempt once and immediately exit.

While we're here, also fix verbose output for `brew services restart`.