### PR TITLE
Use `system_command` instead of `Utils.popen_read`.

### DIFF
--- a/lib/service/formula_wrapper.rb
+++ b/lib/service/formula_wrapper.rb
@@ -209,14 +209,22 @@ module Service
 
     def status_output_success_type
       @status_output_success_type ||= if System.launchctl?
-        result = system_command(System.launchctl.to_s, args: ["list", service_name])
+        result = system_command(
+          System.launchctl.to_s,
+          args:         ["list", service_name],
+          print_stderr: false,
+        )
         output = result.stdout.chomp
 
         if result.success? && output.present?
           success = true
           [output, success, :launchctl_list]
         else
-          result = system_command(System.launchctl.to_s, args: ["print", "#{System.domain_target}/#{service_name}"])
+          result = system_command(
+            System.launchctl.to_s,
+            args:         ["print", "#{System.domain_target}/#{service_name}"],
+            print_stderr: false,
+          )
           output = result.stdout.chomp
           success = result.success? && output.present?
           [output, success, :launchctl_print]

--- a/lib/service/formula_wrapper.rb
+++ b/lib/service/formula_wrapper.rb
@@ -212,7 +212,8 @@ module Service
         result = system_command(
           System.launchctl.to_s,
           args:         ["list", service_name],
-          print_stderr: false,
+          print_stdout: :debug,
+          print_stderr: :debug,
         )
         output = result.stdout.chomp
 
@@ -223,7 +224,8 @@ module Service
           result = system_command(
             System.launchctl.to_s,
             args:         ["print", "#{System.domain_target}/#{service_name}"],
-            print_stderr: false,
+            print_stdout: :debug,
+            print_stderr: :debug,
           )
           output = result.stdout.chomp
           success = result.success? && output.present?

--- a/lib/service/services_cli.rb
+++ b/lib/service/services_cli.rb
@@ -23,7 +23,7 @@ module Service
     # Find all currently running services via launchctl list or systemctl list-units.
     def running
       result = if System.launchctl?
-        system_command(System.launchctl, args: ["list"])
+        system_command(System.launchctl, args: ["list"], print_stderr: false)
       else
         executable, *args = [
           *System.systemctl_args, "list-units",
@@ -32,7 +32,7 @@ module Service
                                    "--no-pager",
                                    "--no-legend"
         ]
-        system_command(executable, args: args)
+        system_command(executable, args: args, print_stderr: false)
       end
 
       result.stdout.chomp

--- a/spec/homebrew/services_cli_spec.rb
+++ b/spec/homebrew/services_cli_spec.rb
@@ -17,11 +17,13 @@ describe Service::ServicesCli do
     it "macOS - returns the currently running services" do
       allow(Service::System).to receive(:launchctl?).and_return(true)
       allow(Service::System).to receive(:systemctl?).and_return(false)
-      allow(Utils).to receive(:popen_read).and_return <<~EOS
-        77513   50  homebrew.mxcl.php
-        495     0   homebrew.mxcl.node_exporter
-        1234    34  homebrew.mxcl.postgresql@14
-      EOS
+      allow(services_cli).to receive(:system_command).and_return instance_double(
+        SystemCommand::Result,
+        stdout: <<~EOS)
+          77513   50  homebrew.mxcl.php
+          495     0   homebrew.mxcl.node_exporter
+          1234    34  homebrew.mxcl.postgresql@14
+        EOS
       expect(services_cli.running).to eq([
         "homebrew.mxcl.php",
         "homebrew.mxcl.node_exporter",
@@ -31,12 +33,14 @@ describe Service::ServicesCli do
 
     it "systemD - returns the currently running services" do
       allow(Service::System).to receive(:launchctl?).and_return(false)
-      allow(Utils).to receive(:popen_read).and_return <<~EOS
-        homebrew.php.service     loaded active running Homebrew PHP service
-        systemd-udevd.service    loaded active running Rule-based Manager for Device Events and Files
-        udisks2.service          loaded active running Disk Manager
-        user@1000.service        loaded active running User Manager for UID 1000
-      EOS
+      allow(services_cli).to receive(:system_command).and_return instance_double(
+        SystemCommand::Result,
+        stdout: <<~EOS)
+          homebrew.php.service     loaded active running Homebrew PHP service
+          systemd-udevd.service    loaded active running Rule-based Manager for Device Events and Files
+          udisks2.service          loaded active running Disk Manager
+          user@1000.service        loaded active running User Manager for UID 1000
+        EOS
       expect(services_cli.running).to eq(["homebrew.php.service"])
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ end
 
 require "active_support/core_ext/string"
 
+require "stub/system_command"
+
 PROJECT_ROOT = Pathname(__dir__).parent.freeze
 Dir.glob("#{PROJECT_ROOT}/lib/**/*.rb").sort.each do |file|
   require file
@@ -137,8 +139,6 @@ module Service
     def odie(string)
       raise TestExit, string
     end
-
-    def odebug(header, string); end
   end
 
   module Commands

--- a/spec/stub/system_command.rb
+++ b/spec/stub/system_command.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class SystemCommand
+  module Mixin
+    def system_command(_cmd, *_args)
+      Result.new
+    end
+  end
+
+  class Result
+    def stdout
+      ""
+    end
+
+    def success?
+      true
+    end
+  end
+end


### PR DESCRIPTION
Previously, output would be broken when using `HOMEBREW_DEBUG=1` and `--json`, since `odebug` outputs to `stdout` (maybe it should always output to `stderr`?). 

`SystemCommand` already automatically handles `HOMEBREW_DEBUG`, so let's use that instead of manually calling `odebug` for every command here.

Bug seen here: https://github.com/reitermarkus/dotfiles/actions/runs/6435999795/job/17478462126#step:3:14451