### PR TITLE
Use `plist` over `rexml`

### DIFF
--- a/lib/service/formula_wrapper.rb
+++ b/lib/service/formula_wrapper.rb
@@ -122,12 +122,13 @@ module Service
 
     def owner
       if System.launchctl? && dest.exist?
-        require "rexml/document"
-
         # read the username from the plist file
-        plist = REXML::Document.new(dest.read)
-        username_xpath = "/plist/dict/key[text()='UserName']/following-sibling::*[1]"
-        plist_username = REXML::XPath.first(plist, username_xpath)&.text
+        plist = begin
+          Plist.parse_xml(dest.read, marshal: false)
+        rescue
+          nil
+        end
+        plist_username = plist["UserName"] if plist
 
         return plist_username if plist_username.present?
       end


### PR DESCRIPTION
REXML is disappearing in Ruby 3 and will move to Homebrew/brew's Gemfile. At this time there are no plans to commit it to the repository as a vendored gem and `brew services` should work without needing to install any extra gems. `plist` is however already there as a committed vendored gem so we can use that. It also has better API.

I haven't tested the `--sudo-service-user` part of this. @MikeMcQuaid you're likely best positioned to test that.