### PR TITLE
Disable `brew services restart --file=`

### DIFF
--- a/cmd/services.rb
+++ b/cmd/services.rb
@@ -91,8 +91,12 @@ module Homebrew
       raise UsageError, "The `#{subcommand}` subcommand does not accept the --all argument!" if args.all?
     end
 
-    if ::Service::Commands::Start::TRIGGERS.include?(subcommand) && args.all? && args.file.present?
-      raise UsageError, "The start subcommand does not accept the --all and --file= arguments at the same time!"
+    if args.file
+      if ::Service::Commands::Start::TRIGGERS.exclude?(subcommand)
+        raise UsageError, "The `#{subcommand}` subcommand does not accept the --file= argument!"
+      elsif args.all?
+        raise UsageError, "The start subcommand does not accept the --all and --file= arguments at the same time!"
+      end
     end
 
     opoo "The --all argument overrides provided formula argument!" if formula.present? && args.all?
@@ -119,7 +123,7 @@ module Homebrew
     when *::Service::Commands::Info::TRIGGERS
       ::Service::Commands::Info.run(targets, verbose: args.verbose?, json: args.json?)
     when *::Service::Commands::Restart::TRIGGERS
-      ::Service::Commands::Restart.run(targets, args.file, verbose: args.verbose?)
+      ::Service::Commands::Restart.run(targets, verbose: args.verbose?)
     when *::Service::Commands::Run::TRIGGERS
       ::Service::Commands::Run.run(targets, verbose: args.verbose?)
     when *::Service::Commands::Start::TRIGGERS

--- a/lib/service/commands/restart.rb
+++ b/lib/service/commands/restart.rb
@@ -12,10 +12,8 @@ module Service
 
       TRIGGERS = %w[restart relaunch reload r].freeze
 
-      def run(targets, custom_plist, verbose:)
+      def run(targets, verbose:)
         return unless ServicesCli.check(targets)
-
-        odeprecated "the restart command with a service file" if custom_plist.present?
 
         ran = []
         started = []

--- a/spec/homebrew/commands/restart_spec.rb
+++ b/spec/homebrew/commands/restart_spec.rb
@@ -12,7 +12,7 @@ describe Service::Commands::Restart do
   describe "#run" do
     it "fails with empty list" do
       expect do
-        described_class.run([], nil, verbose: false)
+        described_class.run([], verbose: false)
       end.to raise_error UsageError, "Formula(e) missing, please provide a formula name or use --all"
     end
 
@@ -21,7 +21,7 @@ describe Service::Commands::Restart do
       expect(Service::ServicesCli).not_to receive(:stop)
       expect(Service::ServicesCli).to receive(:start).once
       service = OpenStruct.new(service_name: "name", loaded?: false)
-      expect(described_class.run([service], nil, verbose: false)).to be_nil
+      expect(described_class.run([service], verbose: false)).to be_nil
     end
 
     it "starts if services are loaded with file" do
@@ -29,7 +29,7 @@ describe Service::Commands::Restart do
       expect(Service::ServicesCli).to receive(:start).once
       expect(Service::ServicesCli).to receive(:stop).once
       service = OpenStruct.new(service_name: "name", loaded?: true, service_file_present?: true)
-      expect(described_class.run([service], nil, verbose: false)).to be_nil
+      expect(described_class.run([service], verbose: false)).to be_nil
     end
 
     it "runs if services are loaded without file" do
@@ -37,7 +37,7 @@ describe Service::Commands::Restart do
       expect(Service::ServicesCli).to receive(:run).once
       expect(Service::ServicesCli).to receive(:stop).once
       service = OpenStruct.new(service_name: "name", loaded?: true, service_file_present?: false)
-      expect(described_class.run([service], nil, verbose: false)).to be_nil
+      expect(described_class.run([service], verbose: false)).to be_nil
     end
   end
 end


### PR DESCRIPTION
`UsageError` is the same as `odisabled` in this case.

Probably should be merged at the same time as 4.2.0 is released, though the error is well overdue so I'm fine with whenever really.