### PR TITLE
Improve behavior of `--all`

### DIFF
--- a/lib/service/formulae.rb
+++ b/lib/service/formulae.rb
@@ -4,15 +4,24 @@ module Service
   module Formulae
     module_function
 
-    # All available services
+    # All available services, with optional filters applied
     # @private
-    def available_services
+    def available_services(loaded: nil, skip_root: false)
       require "formula"
 
-      Formula.installed
+      formulae = Formula.installed
              .map { |formula| FormulaWrapper.new(formula) }
              .select { |formula| formula.service? || formula.plist? }
              .sort_by(&:name)
+
+      if loaded != nil
+        formulae = formulae.select { |formula| formula.loaded? == loaded }
+      end
+      if skip_root
+        formulae = formulae.select { |formula| formula.owner != "root" }
+      end
+
+      return formulae
     end
 
     # List all available services with status, user, and path to the file.

--- a/lib/service/formulae.rb
+++ b/lib/service/formulae.rb
@@ -10,18 +10,14 @@ module Service
       require "formula"
 
       formulae = Formula.installed
-             .map { |formula| FormulaWrapper.new(formula) }
-             .select { |formula| formula.service? || formula.plist? }
-             .sort_by(&:name)
+                        .map { |formula| FormulaWrapper.new(formula) }
+                        .select { |formula| formula.service? || formula.plist? }
+                        .sort_by(&:name)
 
-      if loaded != nil
-        formulae = formulae.select { |formula| formula.loaded? == loaded }
-      end
-      if skip_root
-        formulae = formulae.select { |formula| formula.owner != "root" }
-      end
+      formulae = formulae.select { |formula| formula.loaded? == loaded } unless loaded.nil?
+      formulae = formulae.reject { |formula| formula.owner == "root" } if skip_root
 
-      return formulae
+      formulae
     end
 
     # List all available services with status, user, and path to the file.


### PR DESCRIPTION
This changes how `--all` behaves. When stopping all services, it filters out the services that are already stopped, and vice versa when starting all services.

My motivation for this change is that I have `dnscrypt-proxy` installed which causes `brew services stop --all` to no longer work properly and stop halfway through.

```
$ brew services list
Name           Status  User   File
caddy          none           
dnscrypt-proxy none    root   
grafana        started stefan ~/Library/LaunchAgents/homebrew.mxcl.grafana.plist

$ brew services stop --all
Warning: Service `caddy` is not started.
Error: Service `dnscrypt-proxy` is started as `root`. Try:
  sudo brew services stop dnscrypt-proxy

$ brew services list
Name           Status  User   File
caddy          none           
dnscrypt-proxy none    root   
grafana        started stefan ~/Library/LaunchAgents/homebrew.mxcl.grafana.plist
```

With my changes it works the way I want it to:

```
$ brew services list
Name           Status  User   File
caddy          none           
dnscrypt-proxy none    root   
grafana        started stefan ~/Library/LaunchAgents/homebrew.mxcl.grafana.plist

$ brew services stop --all
Stopping `grafana`... (might take a while)
==> Successfully stopped `grafana` (label: homebrew.mxcl.grafana)

$ brew services list
Name           Status User File
caddy          none        
dnscrypt-proxy none   root 
grafana        none        
```

You'll no longer see ```Warning: Service `X` is not started.``` warnings when using `--all`, which cleans up the output a lot.

If you have root services then `brew services start --all` no longer tries to start them. Perhaps a new switch should be included to allow this to be controlled, e.g. `--include-root`? In my opinion the default should exclude root services since I think it is the exception rather than the rule where you want to include them, right?

```
$ brew services start --all
==> Successfully started `caddy` (label: homebrew.mxcl.caddy)
==> Successfully started `grafana` (label: homebrew.mxcl.grafana)
```

The tests are still passing. Please let me know if you want me to make any changes. If you want me to add to the tests then please let me know. I don't want to spend time on tests unless the changes are desirable.

Thanks!
