### PR TITLE
Gemfile: use `.ruby-version`.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source "https://rubygems.org"
 
+ruby file: ".ruby-version"
+
 group :test do
   gem "activesupport"
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,3 +43,9 @@ DEPENDENCIES
   activesupport
   rspec
   simplecov
+
+RUBY VERSION
+   ruby 3.3.1p55
+
+BUNDLED WITH
+   2.5.9


### PR DESCRIPTION
This ensures it's used consistently by `bundle`.