### PR TITLE
Fix style issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,8 +45,8 @@ jobs:
     - name: Enable linger
       if: matrix.os == 'ubuntu-latest'
       run: |
-        loginctl enable-linger $(whoami)
-        echo "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus" >> $GITHUB_ENV
+        loginctl enable-linger "$(whoami)"
+        echo "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus" >> "$GITHUB_ENV"
 
     - name: Set up Homebrew
       id: set-up-homebrew
@@ -59,8 +59,8 @@ jobs:
 
     - name: Unlink services repo
       run: |
-        rm $(brew --repo homebrew/services)
-        cp -a $PWD $(brew --repo homebrew/services)
+        rm "$(brew --repo homebrew/services)"
+        cp -a "$PWD" "$(brew --repo homebrew/services)"
 
     - name: Test start command
       run: |
@@ -105,5 +105,5 @@ jobs:
 
     - name: Link services repo
       run: |
-        rm -rf $(brew --repo homebrew/services)
-        ln -s $PWD $(brew --repo homebrew/services)
+        rm -rf "$(brew --repo homebrew/services)"
+        ln -s "$PWD" "$(brew --repo homebrew/services)"


### PR DESCRIPTION
`shellcheck` is reporting [SC2046](https://www.shellcheck.net/wiki/SC2046) (Quote this to prevent word splitting) and [SC2086](https://www.shellcheck.net/wiki/SC2086) (Double quote to prevent globbing and word splitting) issues in the `tests.yml` workflow. Adding quotes in affected areas resolves these warning/info messages but I haven't tested these changes, so take this with a grain of salt.

Related to https://github.com/Homebrew/brew/pull/17482