### PR TITLE
cmd/services: improve help text

### DIFF
--- a/cmd/services.rb
+++ b/cmd/services.rb
@@ -17,8 +17,8 @@ module Homebrew
           Manage background services with macOS' `launchctl`(1) daemon manager or
           Linux's `systemctl`(1) service manager.
 
-          If `sudo` is passed, operate on `/Library/LaunchDaemons`/`/usr/lib/systemd/system`  (started at boot).
-          Otherwise, operate on `~/Library/LaunchAgents`/`~/.config/systemd/user` (started at login).
+          If `sudo` is passed, operate on `/Library/LaunchDaemons` or `/usr/lib/systemd/system`  (started at boot).
+          Otherwise, operate on `~/Library/LaunchAgents` or `~/.config/systemd/user` (started at login).
 
           [`sudo`] `brew services` [`list`] (`--json`) (`--debug`):
           List information about all managed services for the current user (or root).


### PR DESCRIPTION
The slash separating the two paths is easily confused for another path
separator. Let's make it less ambiguous by using something that isn't
also a path separator.
