### PR TITLE
Drop unnecessary module_function

### DIFF
--- a/lib/service/commands/cleanup.rb
+++ b/lib/service/commands/cleanup.rb
@@ -3,11 +3,9 @@
 module Service
   module Commands
     module Cleanup
-      module_function
-
       TRIGGERS = %w[cleanup clean cl rm].freeze
 
-      def run
+      def self.run
         cleaned = []
 
         cleaned += ServicesCli.kill_orphaned_services

--- a/lib/service/commands/info.rb
+++ b/lib/service/commands/info.rb
@@ -3,11 +3,9 @@
 module Service
   module Commands
     module Info
-      module_function
-
       TRIGGERS = %w[info i].freeze
 
-      def run(targets, verbose:, json:)
+      def self.run(targets, verbose:, json:)
         return unless ServicesCli.check(targets)
 
         output = targets.map(&:to_hash)
@@ -22,7 +20,7 @@ module Service
         end
       end
 
-      def pretty_bool(bool)
+      def self.pretty_bool(bool)
         return bool if !$stdout.tty? || Homebrew::EnvConfig.no_emoji?
 
         if bool
@@ -32,7 +30,7 @@ module Service
         end
       end
 
-      def output(hash, verbose:)
+      def self.output(hash, verbose:)
         out = "#{Tty.bold}#{hash[:name]}#{Tty.reset} (#{hash[:service_name]})\n"
         out += "Running: #{pretty_bool(hash[:running])}\n"
         out += "Loaded: #{pretty_bool(hash[:loaded])}\n"

--- a/lib/service/commands/kill.rb
+++ b/lib/service/commands/kill.rb
@@ -3,11 +3,9 @@
 module Service
   module Commands
     module Kill
-      module_function
-
       TRIGGERS = %w[kill k].freeze
 
-      def run(targets, verbose:)
+      def self.run(targets, verbose:)
         ServicesCli.check(targets) &&
           ServicesCli.kill(targets, verbose:)
       end

--- a/lib/service/commands/list.rb
+++ b/lib/service/commands/list.rb
@@ -5,11 +5,9 @@ require "service/formulae"
 module Service
   module Commands
     module List
-      module_function
-
       TRIGGERS = [nil, "list", "ls"].freeze
 
-      def run(json: false)
+      def self.run(json: false)
         formulae = Formulae.services_list
         if formulae.blank?
           opoo "No services available to control with `#{Service::ServicesCli.bin}`" if $stderr.tty?
@@ -27,7 +25,7 @@ module Service
 
       # Print the JSON representation in the CLI
       # @private
-      def print_json(formulae)
+      def self.print_json(formulae)
         services = formulae.map do |formula|
           formula.slice(*JSON_FIELDS)
         end
@@ -37,7 +35,7 @@ module Service
 
       # Print the table in the CLI
       # @private
-      def print_table(formulae)
+      def self.print_table(formulae)
         services = formulae.map do |formula|
           status = get_status_string(formula[:status])
           status += formula[:exit_code].to_s if formula[:status] == :error
@@ -67,7 +65,7 @@ module Service
 
       # Get formula status output
       # @private
-      def get_status_string(status)
+      def self.get_status_string(status)
         case status
         when :started, :scheduled then "#{Tty.green}#{status}#{Tty.reset}"
         when :stopped, :none then "#{Tty.default}#{status}#{Tty.reset}"

--- a/lib/service/commands/restart.rb
+++ b/lib/service/commands/restart.rb
@@ -3,8 +3,6 @@
 module Service
   module Commands
     module Restart
-      module_function
-
       # NOTE: The restart command is used to update service files
       # after a package gets updated through `brew upgrade`.
       # This works by removing the old file with `brew services stop`
@@ -12,7 +10,7 @@ module Service
 
       TRIGGERS = %w[restart relaunch reload r].freeze
 
-      def run(targets, verbose:)
+      def self.run(targets, verbose:)
         return unless ServicesCli.check(targets)
 
         ran = []

--- a/lib/service/commands/run.rb
+++ b/lib/service/commands/run.rb
@@ -3,11 +3,9 @@
 module Service
   module Commands
     module Run
-      module_function
-
       TRIGGERS = ["run"].freeze
 
-      def run(targets, verbose:)
+      def self.run(targets, verbose:)
         ServicesCli.check(targets) &&
           ServicesCli.run(targets, verbose:)
       end

--- a/lib/service/commands/start.rb
+++ b/lib/service/commands/start.rb
@@ -3,11 +3,9 @@
 module Service
   module Commands
     module Start
-      module_function
-
       TRIGGERS = %w[start launch load s l].freeze
 
-      def run(targets, custom_plist, verbose:)
+      def self.run(targets, custom_plist, verbose:)
         ServicesCli.check(targets) &&
           ServicesCli.start(targets, custom_plist, verbose:)
       end

--- a/lib/service/commands/stop.rb
+++ b/lib/service/commands/stop.rb
@@ -3,11 +3,9 @@
 module Service
   module Commands
     module Stop
-      module_function
-
       TRIGGERS = %w[stop unload terminate term t u].freeze
 
-      def run(targets, verbose:, no_wait:)
+      def self.run(targets, verbose:, no_wait:)
         ServicesCli.check(targets) &&
           ServicesCli.stop(targets, verbose:, no_wait:)
       end

--- a/lib/service/formulae.rb
+++ b/lib/service/formulae.rb
@@ -2,11 +2,9 @@
 
 module Service
   module Formulae
-    module_function
-
     # All available services, with optional filters applied
     # @private
-    def available_services(loaded: nil, skip_root: false)
+    def self.available_services(loaded: nil, skip_root: false)
       require "formula"
 
       formulae = Formula.installed
@@ -21,7 +19,7 @@ module Service
     end
 
     # List all available services with status, user, and path to the file.
-    def services_list
+    def self.services_list
       available_services.map(&:to_hash)
     end
   end

--- a/lib/service/system.rb
+++ b/lib/service/system.rb
@@ -4,49 +4,47 @@ module Service
   module System
     extend FileUtils
 
-    module_function
-
     # Path to launchctl binary.
-    def launchctl
+    def self.launchctl
       @launchctl ||= which("launchctl")
     end
 
     # Is this a launchctl system
-    def launchctl?
+    def self.launchctl?
       launchctl.present?
     end
 
     # Path to systemctl binary.
-    def systemctl
+    def self.systemctl
       @systemctl ||= which("systemctl")
     end
 
     # Is this a systemd system
-    def systemctl?
+    def self.systemctl?
       systemctl.present?
     end
 
     # Command scope modifier
-    def systemctl_scope
+    def self.systemctl_scope
       root? ? "--system" : "--user"
     end
 
     # Arguments to run systemctl.
-    def systemctl_args
+    def self.systemctl_args
       @systemctl_args ||= [systemctl, systemctl_scope]
     end
 
     # Woohoo, we are root dude!
-    def root?
+    def self.root?
       Process.euid.zero?
     end
 
     # Current user running `[sudo] brew services`.
-    def user
+    def self.user
       @user ||= ENV["USER"].presence || Utils.safe_popen_read("/usr/bin/whoami").chomp
     end
 
-    def user_of_process(pid)
+    def self.user_of_process(pid)
       if pid.nil? || pid.zero?
         user
       else
@@ -55,7 +53,7 @@ module Service
     end
 
     # Run at boot.
-    def boot_path
+    def self.boot_path
       if launchctl?
         Pathname.new("/Library/LaunchDaemons")
       elsif systemctl?
@@ -64,7 +62,7 @@ module Service
     end
 
     # Run at login.
-    def user_path
+    def self.user_path
       if launchctl?
         Pathname.new("#{Dir.home}/Library/LaunchAgents")
       elsif systemctl?
@@ -73,11 +71,11 @@ module Service
     end
 
     # If root, return `boot_path`, else return `user_path`.
-    def path
+    def self.path
       root? ? boot_path : user_path
     end
 
-    def domain_target
+    def self.domain_target
       if root?
         "system"
       elsif (ssh_tty = ENV.fetch("HOMEBREW_SSH_TTY", nil).present? && File.stat("/dev/console").uid != Process.uid) ||

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,96 +35,84 @@ RSpec.configure do |config|
 end
 
 module Formatter
-  module_function
-
-  def success(string)
+  def self.success(string)
     string
   end
 
-  def error(string)
+  def self.error(string)
     string
   end
 end
 
 module Tty
-  module_function
-
-  def green
+  def self.green
     "<GREEN>"
   end
 
-  def yellow
+  def self.yellow
     "<YELLOW>"
   end
 
-  def red
+  def self.red
     "<RED>"
   end
 
-  def default
+  def self.default
     "<DEFAULT>"
   end
 
-  def bold
+  def self.bold
     "<BOLD>"
   end
 
-  def reset
+  def self.reset
     "<RESET>"
   end
 end
 
 module Homebrew
   module EnvConfig
-    module_function
-
-    def no_emoji?
+    def self.no_emoji?
       false
     end
   end
 end
 
 module Utils
-  module_function
-
-  def popen_read(*_cmd)
+  def self.popen_read(*_cmd)
     ""
   end
 
-  def safe_popen_read(*_args)
+  def self.safe_popen_read(*_args)
     ""
   end
 end
 
 module Service
   module System
-    module_function
-
-    def which(cmd)
+    def self.which(cmd)
       "/bin/#{cmd}"
     end
   end
 
   module ServicesCli
-    module_function
-
-    def safe_system(*_cmd)
+    def self.safe_system(*_cmd)
       ""
     end
 
-    def quiet_system(*_cmd)
+    def self.quiet_system(*_cmd)
       true
     end
 
-    def odie(string)
+    def self.odie(string)
       raise TestExit, string
     end
 
-    def opoo(string)
+    def self.opoo(string)
       puts string
     end
 
-    def ohai(string)
+    def self.ohai(string)
       puts string
     end
   end
@@ -143,9 +131,7 @@ module Service
 
   module Commands
     module List
-      module_function
-
-      def opoo(string)
+      def self.opoo(string)
         puts string
       end
     end


### PR DESCRIPTION
Should help #711 if CI passes

These modules should be called as `Service::Whatever.method` and never via `include Service::Whatever`, so remove `module_function` to forbid the latter and get stronger typing as a result.