### PR TITLE
Improve handling of systemctl under mixed UID environments

### DIFF
--- a/lib/service/formula_wrapper.rb
+++ b/lib/service/formula_wrapper.rb
@@ -105,7 +105,7 @@ module Service
         _, status_success, = status_output_success_type
         status_success
       elsif System.systemctl?
-        quiet_system(*System.systemctl_args, "status", service_file.basename)
+        System::Systemctl.quiet_run("status", service_file.basename)
       end
     end
 
@@ -223,10 +223,10 @@ module Service
           [output, success, :launchctl_print]
         end
       elsif System.systemctl?
-        cmd = [*System.systemctl_args, "status", service_name]
-        output = Utils.popen_read(*cmd).chomp
+        cmd = ["status", service_name]
+        output = System::Systemctl.popen_read(*cmd).chomp
         success = $CHILD_STATUS.present? && $CHILD_STATUS.success? && output.present?
-        odebug cmd.join(" "), output
+        odebug [System::Systemctl.executable, System::Systemctl.scope, *cmd].join(" "), output
         [output, success, :systemctl]
       end
     end

--- a/lib/service/system.rb
+++ b/lib/service/system.rb
@@ -1,6 +1,8 @@
 # typed: true
 # frozen_string_literal: true
 
+require_relative "system/systemctl"
+
 module Service
   module System
     extend FileUtils
@@ -15,24 +17,9 @@ module Service
       launchctl.present?
     end
 
-    # Path to systemctl binary.
-    def self.systemctl
-      @systemctl ||= which("systemctl")
-    end
-
     # Is this a systemd system
     def self.systemctl?
-      systemctl.present?
-    end
-
-    # Command scope modifier
-    def self.systemctl_scope
-      root? ? "--system" : "--user"
-    end
-
-    # Arguments to run systemctl.
-    def self.systemctl_args
-      @systemctl_args ||= [systemctl, systemctl_scope]
+      Systemctl.executable.present?
     end
 
     # Woohoo, we are root dude!

--- a/lib/service/system/systemctl.rb
+++ b/lib/service/system/systemctl.rb
@@ -1,0 +1,43 @@
+# typed: true
+# frozen_string_literal: true
+
+module Service
+  module System
+    module Systemctl
+      def self.executable
+        @executable ||= which("systemctl")
+      end
+
+      def self.scope
+        System.root? ? "--system" : "--user"
+      end
+
+      def self.run(*args)
+        _run(*args, mode: :default)
+      end
+
+      def self.quiet_run(*args)
+        _run(*args, mode: :quiet)
+      end
+
+      def self.popen_read(*args)
+        _run(*args, mode: :read)
+      end
+
+      private_class_method def self._run(*args, mode:)
+        require "system_command"
+        result = SystemCommand.run(executable,
+                                   args:         [scope, *args.map(&:to_s)],
+                                   print_stdout: mode == :default,
+                                   print_stderr: mode == :default,
+                                   must_succeed: mode == :default,
+                                   reset_uid:    true)
+        if mode == :read
+          result.stdout
+        elsif mode == :quiet
+          result.success?
+        end
+      end
+    end
+  end
+end

--- a/spec/homebrew/formula_wrapper_spec.rb
+++ b/spec/homebrew/formula_wrapper_spec.rb
@@ -112,6 +112,7 @@ describe Service::FormulaWrapper do
 
     it "systemD - outputs if the service is loaded" do
       allow(Service::System).to receive_messages(launchctl?: false, systemctl?: true)
+      allow(Service::System::Systemctl).to receive(:quiet_run).and_return(false)
       allow(Utils).to receive(:safe_popen_read)
       expect(service.loaded?).to be(false)
     end

--- a/spec/homebrew/system/systemctl_spec.rb
+++ b/spec/homebrew/system/systemctl_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Service::System::Systemctl do
+  describe ".scope" do
+    it "outputs systemctl scope for user" do
+      allow(Service::System).to receive(:root?).and_return(false)
+      expect(described_class.scope).to eq("--user")
+    end
+
+    it "outputs systemctl scope for root" do
+      allow(Service::System).to receive(:root?).and_return(true)
+      expect(described_class.scope).to eq("--system")
+    end
+  end
+
+  describe ".executable" do
+    it "outputs systemctl command location" do
+      expect(described_class.executable).to eq("/bin/systemctl")
+    end
+  end
+end

--- a/spec/homebrew/system_spec.rb
+++ b/spec/homebrew/system_spec.rb
@@ -21,24 +21,6 @@ describe Service::System do
     end
   end
 
-  describe "#systemctl_scope" do
-    it "outputs systemctl scope for user" do
-      allow(described_class).to receive(:root?).and_return(false)
-      expect(described_class.systemctl_scope).to eq("--user")
-    end
-
-    it "outputs systemctl scope for root" do
-      allow(described_class).to receive(:root?).and_return(true)
-      expect(described_class.systemctl_scope).to eq("--system")
-    end
-  end
-
-  describe "#systemctl" do
-    it "outputs systemctl command location" do
-      expect(described_class.systemctl).to eq("/bin/systemctl")
-    end
-  end
-
   describe "#root?" do
     it "checks if the command is ran as root" do
       expect(described_class.root?).to be(false)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,8 @@ require "bundler"
 require "rspec/support/object_formatter"
 require "stub/exceptions"
 
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "stub"))
+
 RSpec.configure do |config|
   config.filter_run_when_matching :focus
   config.expect_with :rspec do |c|
@@ -95,6 +97,12 @@ module Service
     def self.which(cmd)
       "/bin/#{cmd}"
     end
+
+    module Systemctl
+      def self.which(cmd)
+        System.which(cmd)
+      end
+    end
   end
 
   module ServicesCli
@@ -146,4 +154,10 @@ class Array
   end
 
   def verbose?; end
+end
+
+class SystemCommand
+  def self.run(_executable, **_options)
+    OpenStruct.new(stdout: "", success?: true)
+  end
 end

--- a/spec/stub/system_command.rb
+++ b/spec/stub/system_command.rb
@@ -1,0 +1,1 @@
+# frozen_string_literal: true


### PR DESCRIPTION
When EUID != UID, `systemctl` basically ignores any environment variable and is largely nonfunctional.

`system_command` has handling to support this so wrap `systemctl` calls to make use of that.