### PR TITLE
Add `--max-wait` flag for `stop` subcommand

### DIFF
--- a/cmd/services.rb
+++ b/cmd/services.rb
@@ -54,9 +54,12 @@ module Homebrew
         EOS
         flag "--file=", description: "Use the service file from this location to `start` the service."
         flag "--sudo-service-user=", description: "When run as root on macOS, run the service(s) as this user."
+        flag "--max-wait=", description: "Wait at most this many seconds for `stop` to finish stopping a service. " \
+                                         "Omit this flag or set this to zero (0) seconds to wait indefinitely."
         switch "--all", description: "Run <subcommand> on all services."
         switch "--json", description: "Output as JSON."
         switch "--no-wait", description: "Don't wait for `stop` to finish stopping the service."
+        conflicts "--max-wait=", "--no-wait"
         named_args max: 2
       end
 
@@ -146,7 +149,8 @@ module Homebrew
         when *::Service::Commands::Start::TRIGGERS
           ::Service::Commands::Start.run(targets, args.file, verbose: args.verbose?)
         when *::Service::Commands::Stop::TRIGGERS
-          ::Service::Commands::Stop.run(targets, verbose: args.verbose?, no_wait: args.no_wait?)
+          max_wait = args.max_wait.to_f
+          ::Service::Commands::Stop.run(targets, verbose: args.verbose?, no_wait: args.no_wait?, max_wait:)
         when *::Service::Commands::Kill::TRIGGERS
           ::Service::Commands::Kill.run(targets, verbose: args.verbose?)
         else

--- a/cmd/services.rbi
+++ b/cmd/services.rbi
@@ -23,4 +23,7 @@ class Homebrew::Cmd::Services::Args < Homebrew::CLI::Args
 
   sig { returns(T.nilable(String)) }
   def sudo_service_user; end
+
+  sig { returns(T.nilable(String)) }
+  def max_wait; end
 end

--- a/lib/service/commands/stop.rb
+++ b/lib/service/commands/stop.rb
@@ -6,9 +6,9 @@ module Service
     module Stop
       TRIGGERS = %w[stop unload terminate term t u].freeze
 
-      def self.run(targets, verbose:, no_wait:)
+      def self.run(targets, verbose:, no_wait:, max_wait:)
         ServicesCli.check(targets) &&
-          ServicesCli.stop(targets, verbose:, no_wait:)
+          ServicesCli.stop(targets, verbose:, no_wait:, max_wait:)
       end
     end
   end


### PR DESCRIPTION
We currently only have a choice between passing `--no-wait` or omitting
it. In the former, we don't wait at all for services to stop. In the
latter, we wait as long as it takes (which could be forever, if some
services have frozen for some reason).

This enables a middle ground where we wait only up to a given amount of
time until we're no longer willing to wait for a service to stop.

Will probably needs tests.
