### PR TITLE
Bump `cmd` files to Sorbet `typed: strict`

### DIFF
--- a/cmd/services.rb
+++ b/cmd/services.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 homebrew_version = if HOMEBREW_VERSION.present?
@@ -63,6 +63,7 @@ module Homebrew
         named_args max: 2
       end
 
+      sig { override.void }
       def run
         # pbpaste's exit status is a proxy for detecting the use of reattach-to-user-namespace
         if ENV["HOMEBREW_TMUX"] && (File.exist?("/usr/bin/pbpaste") && !quiet_system("/usr/bin/pbpaste"))


### PR DESCRIPTION
- Part of https://github.com/Homebrew/brew/issues/17297, as this was easy.